### PR TITLE
stop closing cell during IME is composing

### DIFF
--- a/src/components/overlay/editors/text.tsx
+++ b/src/components/overlay/editors/text.tsx
@@ -24,7 +24,7 @@ export class TextEditor implements Edition.EditorBase {
     const isEnter = isEnterKey(e.code);
     const isKeyTab = isTab(e.code);
 
-    if ((isKeyTab || isEnter) && e.target && this.saveCallback) {
+    if ((isKeyTab || isEnter) && e.target && this.saveCallback && !e.isComposing) {
       // blur is needed to avoid autoscroll
       this.editInput.blur();
       // request callback which will close cell after all


### PR DESCRIPTION
Thank you for the great library.

While editing a table cell, if you convert the characters using Japanese input editor(IME) and press the Enter button, the edit mode will end.

I think the correct (common) behavior is to end the edit mode when all the character conversions are done and the enter button is pressed.

I fixed, and I hope you'll merge it after you review it.
