### PR TITLE
In a string comparison equals doesn't work

### DIFF
--- a/src/plugins/filter/conditions/equal.ts
+++ b/src/plugins/filter/conditions/equal.ts
@@ -7,7 +7,7 @@ const eq: LogicFunction = (value: LogicFunctionParam, extra?: LogicFunctionExtra
   if (typeof value !== 'string') {
     value = JSON.stringify(value);
   }
-  return value.toLocaleLowerCase() === extra;
+  return value.toLocaleLowerCase() === extra.toString().toLocaleLowerCase();
 };
 
 export const notEq: LogicFunction = (value: LogicFunctionParam, extra?: LogicFunctionExtraParam) => !eq(value, extra);


### PR DESCRIPTION
In filter plugin equals condition doesn't work if data is not lowercase. The comparison is between value lowercased and extra that is not lowercased. In the 'contains' filter both sides are lowercased.