### PR TITLE
Update autoSizeColumn.ts

### DIFF
--- a/src/plugins/autoSizeColumn.ts
+++ b/src/plugins/autoSizeColumn.ts
@@ -144,7 +144,7 @@ export default class AutoSizeColumn extends BasePlugin {
       const sizes: RevoGrid.ViewSettingSizeProp = {};
       each(autoSize[type], rgCol => {
         // calculate size
-        rgCol.size = sizes[rgCol.index] = source.reduce((prev, rgRow) => Math.max(prev, this.getLength(rgRow[rgCol.prop])), 0);
+        rgCol.size = sizes[rgCol.index] = source.reduce((prev, rgRow) => Math.max(prev, this.getLength(rgRow[rgCol.prop])), this.getLength(rgCol.name || ''));
       });
       this.providers.dimensionProvider.setDimensionSize(type, sizes);
     });


### PR DESCRIPTION
autoSizeColumns plugins update to include length of name of column. The autosize columns make the column too small to read the header if the data length is small but header is long. This fixes that problem.