### PR TITLE
fix: filter dialog is out of view

### DIFF
--- a/src/plugins/filter/filter.plugin.tsx
+++ b/src/plugins/filter/filter.plugin.tsx
@@ -177,9 +177,14 @@ export default class FilterPlugin extends BasePlugin {
     this.pop.filterTypes = this.getColumnFilter(e.detail.filter);
     this.pop.show({
       ...this.filterCollection[prop],
-      x: buttonPos.x - gridPos.x,
+      x: -9999,
       y: buttonPos.y - gridPos.y + buttonPos.height,
       prop,
+    });
+    // fix filter dialog is out of view
+    setTimeout(async () => {
+      const { width } = this.pop.getBoundingClientRect();
+      this.pop.style.left = Math.min(buttonPos.x - gridPos.x, gridPos.width - width - 20) + 'px';
     });
   }
 


### PR DESCRIPTION
### before:
![image](https://github.com/revolist/revogrid/assets/1769037/04a3df87-0225-4cd2-b662-837ea72b9380)
### after:
![image](https://github.com/revolist/revogrid/assets/1769037/46674b61-8a24-4645-ab04-83c041fd14a8)
