### PR TITLE
fix: When trimming rows, the row header should use visible source

### DIFF
--- a/src/components/rowHeaders/revogr-row-headers.tsx
+++ b/src/components/rowHeaders/revogr-row-headers.tsx
@@ -33,10 +33,13 @@ export class RevogrRowHeaders {
     /** render viewports rows */
     let totalLength = 1;
     for (let data of this.dataPorts) {
-      const itemCount = data.dataStore.get('items').length;
+      const items = data.dataStore.get('items');
+      const itemCount = items.length;
+      const source = data.dataStore.get('source');
+      const visibleSourceItems = items.map(v => source[v]); // from src/store/dataSource/data.store.ts
       // initiate row data
       const dataStore = new DataStore<RevoGrid.DataType, RevoGrid.DimensionRows>(data.type);
-      dataStore.updateData(data.dataStore.get('source'));
+      dataStore.updateData(visibleSourceItems);
       // initiate column data
       const colData = new DataStore<RevoGrid.ColumnRegular, RevoGrid.DimensionCols>('colPinStart');
       const column = {


### PR DESCRIPTION
before:
![image](https://github.com/revolist/revogrid/assets/1769037/416d5f94-b6ab-4e15-944a-be0daa7452c1)
after:
![image](https://github.com/revolist/revogrid/assets/1769037/16c5d23b-758b-4955-92f5-a4883e8fbe92)
