### PR TITLE
Fix Android 'Enter' input

### DIFF
--- a/src/components/overlay/editors/text.tsx
+++ b/src/components/overlay/editors/text.tsx
@@ -1,5 +1,5 @@
 import { h } from '@stencil/core';
-import { isEnterKey, isTab } from '../../../utils/keyCodes.utils';
+import { isEnterKey, isEnterKeyValue, isTab, isTabKeyValue } from '../../../utils/keyCodes.utils';
 import { Edition, RevoGrid } from '../../../interfaces';
 import { timeout } from '../../../utils/utils';
 
@@ -26,8 +26,8 @@ export class TextEditor implements Edition.EditorBase {
   }
 
   private onKeyDown(e: KeyboardEvent): void {
-    const isEnter = isEnterKey(e.code);
-    const isKeyTab = isTab(e.code);
+    const isEnter = isEnterKeyValue(e.key);
+    const isKeyTab = isTabKeyValue(e.key);
 
     if ((isKeyTab || isEnter) && e.target && this.saveCallback && !e.isComposing) {
       // blur is needed to avoid autoscroll
@@ -42,6 +42,7 @@ export class TextEditor implements Edition.EditorBase {
     return (
       <input
         type="text"
+        enterkeyhint="enter"
         value={this.editCell?.val || ''}
         ref={el => {
           this.editInput = el;

--- a/src/components/overlay/keyboard.service.ts
+++ b/src/components/overlay/keyboard.service.ts
@@ -2,7 +2,7 @@ import { Observable, Selection } from '../../interfaces';
 import { getRange } from '../../store/selection/selection.helpers';
 import SelectionStoreService from '../../store/selection/selection.store.service';
 import { codesLetter } from '../../utils/keyCodes';
-import { isClear, isCtrlKey, isEnterKey, isLetterKey } from '../../utils/keyCodes.utils';
+import { isClear, isCtrlKey, isEnterKeyValue, isLetterKey } from '../../utils/keyCodes.utils';
 import { timeout } from '../../utils/utils';
 import { EventData, getCoordinate, isAfterLast, isBeforeFirst } from './selection.utils';
 
@@ -58,7 +58,7 @@ export class KeyboardService {
     }
 
     // pressed enter
-    if (isEnterKey(e.code)) {
+    if (isEnterKeyValue(e.key)) {
       this.sv.doEdit();
       return;
     }

--- a/src/utils/keyCodes.ts
+++ b/src/utils/keyCodes.ts
@@ -66,5 +66,11 @@ enum codesLetter {
   SHIFT = 'Shift',
 }
 
+enum keyValues {
+  ENTER = 'Enter', // Enter + NumpadEnter
+  TAB = 'Tab',
+}
+
 export default codes;
 export { codesLetter };
+export { keyValues };

--- a/src/utils/keyCodes.utils.ts
+++ b/src/utils/keyCodes.utils.ts
@@ -1,4 +1,4 @@
-import KeyCodesEnum, { codesLetter } from './keyCodes';
+import KeyCodesEnum, { codesLetter, keyValues } from './keyCodes';
 import OsPlatform from './platform';
 import includes from 'lodash/includes';
 
@@ -70,6 +70,15 @@ export function isTab(code: string): boolean {
   return codesLetter.TAB === code;
 }
 
+// does not work with virtual keyboard on android
 export function isEnterKey(code: string): boolean {
   return code === codesLetter.ENTER || code === codesLetter.ENTER_NUM;
+}
+
+export function isTabKeyValue (key: string): boolean {
+  return keyValues.TAB === key;
+}
+
+export function isEnterKeyValue (key: string): boolean {
+  return keyValues.ENTER === key;
 }


### PR DESCRIPTION
With a virtual keyboard on Android, the keyEvent.code return "". Other platforms, we have a 'Enter'. Currently, we cannot modify cells on Android devices (tablets or smartphones)