### PR TITLE
Enable import injection to support Vite

### DIFF
--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -28,6 +28,8 @@ export const config: Config = {
     appendChildSlotFix: false,
     cloneNodeFix: false,
     slotChildNodesFix: false,
+    // Required by Vite to bundle a Stencil project (https://github.com/vitejs/vite/issues/12434#issuecomment-1471305880)
+    enableImportInjection: true,
   },
 
   // buildEs5: 'prod',


### PR DESCRIPTION
When trying to bundle a 4.7.0-next version of Revogrid with Vite 5 in a Vue 3 project (using vue3-datagrid next branch) I encountered a problem when a bundled project refused to load revogrid. The error was specifically: "TypeError: Failed to fetch dynamically imported module".
A solution that resolved the problem was to add "enableImportInjection" extra to Stencil build as this comment stated: https://github.com/vitejs/vite/issues/12434#issuecomment-1471305880