### PR TITLE
fix(filter): remove class reset,save,cancel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@revolist/revogrid",
-  "version": "4.8.13",
+  "version": "4.8.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@revolist/revogrid",
-      "version": "4.8.13",
+      "version": "4.8.16",
       "license": "MIT",
       "devDependencies": {
         "@angular/core": "^18.1.2",

--- a/src/plugins/filter/filter.pop.tsx
+++ b/src/plugins/filter/filter.pop.tsx
@@ -231,14 +231,14 @@ export class FilterPanel {
         </div>
         <div class="filter-actions">
           {this.disableDynamicFiltering &&
-            <button class="revo-button green save"  onClick={() => this.onSave()}>
+            <button id="revo-button-save" aria-label="save" class="revo-button green"  onClick={() => this.onSave()}>
               {capts.save}
             </button>
           }
-          <button class="revo-button light reset" onClick={() => this.onReset()}>
+          <button id="revo-button-reset" aria-label="reset" class="revo-button light" onClick={() => this.onReset()}>
             {capts.reset}
           </button>
-          <button class="revo-button light cancel" onClick={() => this.onCancel()}>
+          <button id="revo-button-cancel" aria-label="cancel" class="revo-button light" onClick={() => this.onCancel()}>
             {capts.cancel}
           </button>
         </div>


### PR DESCRIPTION
Issue: https://github.com/revolist/revogrid/issues/486

Remove the css class from the filter popup button, due its causing problems with other css frameworks. Add id and arialabel to buttons

![image](https://github.com/user-attachments/assets/d430780c-f653-4da5-bc64-200c9051389d)
![image](https://github.com/user-attachments/assets/83dbfd32-b486-4000-bbb9-065367f75458)
