### PR TITLE
add plugin add-rows-on-past

### DIFF
--- a/src/plugins/add-rows-on-past.plugin.ts
+++ b/src/plugins/add-rows-on-past.plugin.ts
@@ -1,0 +1,55 @@
+import { PluginProviders } from "../types/plugin.types";
+import { BasePlugin } from "./base.plugin";
+
+  /**
+   * Automatically adds new rows when pasted data is larger than current rows
+   * @event newRows - is triggered when new rows are added. Data of new rows can be filled with default values. If the event is prevented, no rows will be added. Event data: { newRows: RowData[] }
+   */
+export class AutoAddRowsPlugin extends BasePlugin {
+    constructor(revogrid: HTMLRevoGridElement, providers: PluginProviders) {
+        super(revogrid, providers);
+        this.addEventListener("beforepasteapply", (evt) => this.handleBeforePasteApply(evt));
+    }
+
+    handleBeforePasteApply(event: CustomEvent<{ raw: string, parsed: string[][], event: ClipboardEvent }>) {
+        const start = this.providers.selection.focused;
+        const isEditing = this.providers.selection.edit != null;
+
+        if (!start || isEditing) {
+            return;
+        }
+
+        const rowLength = this.providers.data.stores.rgRow.store.get('items').length;
+
+        const endRow = start.y + event.detail.parsed.length;
+
+        if(rowLength < endRow) {
+
+            const count = endRow - rowLength;
+            const newRows = [];
+
+            for(let i = 0; i < count; i++) {
+                newRows.push({ index: rowLength + i, data: {} });
+            }
+
+            const event = this.emit('newRows', { newRows: newRows });
+
+            if(event.defaultPrevented) {
+                return;
+            }
+
+            const items = this.providers.data.stores.rgRow.store.get('source');
+
+            items.push(...event.detail.newRows.map(j => j.data))
+
+
+            this.providers.data.setData(items);
+        }
+
+
+    }
+
+    override clearSubscriptions(): void {
+        this.removeEventListener('beforepasteapply');
+    }
+}

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -10,3 +10,4 @@ export * from './groupingRow/grouping.row.plugin';
 export * from './moveColumn/column.drag.plugin';
 export * from './sorting/sorting.plugin';
 export * from './sorting/sorting.sign';
+export * from "./add-rows-on-past.plugin";


### PR DESCRIPTION
This plugin adds new rows to the data if the number of entries is greater than the current data count. 

Closes  #338