### PR TITLE
feat: cell edit catch on parent level

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@revolist/revogrid",
-  "version": "4.11.10",
+  "version": "4.11.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@revolist/revogrid",
-      "version": "4.11.10",
+      "version": "4.11.11",
       "license": "MIT",
       "devDependencies": {
         "@angular/core": "^18.1.2",

--- a/src/components/overlay/revogr-overlay-selection.tsx
+++ b/src/components/overlay/revogr-overlay-selection.tsx
@@ -543,18 +543,6 @@ export class OverlaySelection {
           editCell.x,
           this.editors,
         )}
-        onCloseedit={e => this.closeEdit(e)}
-        onCelledit={e => {
-          const saveEv = this.beforeCellSave.emit(e.detail);
-          if (!saveEv.defaultPrevented) {
-            this.cellEdit(saveEv.detail);
-          }
-
-          // if not clear navigate to next cell after edit
-          if (!saveEv.detail.preventFocus) {
-            this.focusNext();
-          }
-        }}
       />
     );
   }
@@ -613,6 +601,18 @@ export class OverlaySelection {
         onDblClick={(e: MouseEvent) => this.onElementDblClick(e)}
         onMouseDown={(e: MouseEvent) => this.onElementMouseDown(e)}
         onTouchStart={(e: TouchEvent) => this.onElementMouseDown(e, true)}
+        onCloseedit={(e: CustomEvent<boolean | undefined>) => this.closeEdit(e)}
+        onCelledit={(e: CustomEvent<SaveDataDetails>) => {
+          const saveEv = this.beforeCellSave.emit(e.detail);
+          if (!saveEv.defaultPrevented) {
+            this.cellEdit(saveEv.detail);
+          }
+
+          // if not clear navigate to next cell after edit
+          if (!saveEv.detail.preventFocus) {
+            this.focusNext();
+          }
+        }}
       >
         {nodes}
         <slot name="data" />


### PR DESCRIPTION
Provide new way to catch cell edit event
This would improve a way to access editor events from other system parts