### PR TITLE
fix: #701

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@revolist/revogrid",
-  "version": "4.11.16",
+  "version": "4.12.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@revolist/revogrid",
-      "version": "4.11.16",
+      "version": "4.12.9",
       "license": "MIT",
       "devDependencies": {
         "@angular/core": "^18.1.2",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -154,7 +154,7 @@ export namespace Components {
         /**
           * Get the currently selected Range.
          */
-        "getSelectedRange": () => Promise<RangeArea | null>;
+        "getSelectedRange": () => Promise<(RangeArea & AllDimensionType) | null>;
         /**
           * Get data from source
          */

--- a/src/components/overlay/revogr-overlay-selection.tsx
+++ b/src/components/overlay/revogr-overlay-selection.tsx
@@ -52,6 +52,7 @@ import type {
   ChangedRange,
   BeforeRangeSaveDataDetails,
   SaveDataDetails,
+  EditCellStore,
 } from '@type';
 
 /**
@@ -896,7 +897,7 @@ export class OverlaySelection {
     return focus && !this.columnService?.isReadOnly(focus.y, focus.x);
   }
 
-  get edited() {
+  get edited(): EditCellStore | null {
     return this.selectionStore.get('edit');
   }
 

--- a/src/components/revoGrid/viewport.helpers.ts
+++ b/src/components/revoGrid/viewport.helpers.ts
@@ -2,8 +2,20 @@
  * Collects data for pinned columns in the required @ViewportProps format.
  */
 
-import { DimensionRows, MultiDimensionType, SlotType, Cell, ViewportColumn } from '@type';
-
+import type {
+  DimensionRows,
+  MultiDimensionType,
+  SlotType,
+  Cell,
+  ViewportColumn,
+  ColumnRegular,
+  DimensionCols,
+  ViewportState,
+  DimensionSettingsState,
+  DataType,
+} from '@type';
+import type { Observable } from '../../utils';
+import type { DSourceState } from '../../store';
 /**
  * Represents the slot names for the viewport slots.
  */
@@ -34,13 +46,30 @@ export function getLastCell(
   };
 }
 
+/**
+ * Represents the partition of viewport data.
+ */
+export type VPPartition = {
+  colData: Observable<DSourceState<ColumnRegular, DimensionCols>>;
+  viewportCol: Observable<ViewportState>;
+  viewportRow: Observable<ViewportState>;
+  lastCell: Cell;
+  slot: SlotType;
+  type: DimensionRows;
+  canDrag: boolean;
+  position: Cell;
+  dataStore: Observable<DSourceState<DataType, DimensionRows>>;
+  dimensionCol: Observable<DimensionSettingsState>;
+  dimensionRow: Observable<DimensionSettingsState>;
+  style?: { height: string };
+};
 
 export function viewportDataPartition(
   data: ViewportColumn,
   type: DimensionRows,
   slot: SlotType,
   fixed?: boolean,
-) {
+): VPPartition {
   return {
     colData: data.colStore,
     viewportCol: data.viewports[data.colType].store,
@@ -59,5 +88,3 @@ export function viewportDataPartition(
       : undefined,
   };
 }
-
-export type VPPartition = ReturnType<typeof viewportDataPartition>;

--- a/src/store/vp/viewport.helpers.ts
+++ b/src/store/vp/viewport.helpers.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   DimensionSettingsState,
   PositionItem,
   ViewSettingSizeProp,


### PR DESCRIPTION
## Summary

- **Refactor**
	- Enhanced the structure of selection data to provide more detailed range information.
	- Added explicit type definitions for edit-related properties for improved clarity.
	- Introduced a structured approach to partition viewport data, optimizing its handling.
  
- **Chore**
	- Updated type import statements for clearer separation between type declarations and runtime code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the return type of the `getSelectedRange` method to provide more detailed range information.
	- Added explicit return type for the `edited` getter to improve clarity.
	- Introduced a structured type definition for partitioning viewport data, optimizing its handling.

- **Chore**
	- Updated type import statements for clearer separation between type declarations and runtime code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->