### PR TITLE
fix: #740 - recalculate viewport size on header and footer change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "@revolist/revogrid",
-  "version": "4.15.5",
+  "version": "4.15.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@revolist/revogrid",
-      "version": "4.15.5",
+      "version": "4.15.6",
       "license": "MIT",
       "devDependencies": {
         "@angular/core": "^18.1.2",
-        "@juggle/resize-observer": "^3.4.0",
         "@revolist/stencil-vue2-output-target": "^0.0.6",
         "@revolist/svelte-output-target": "0.0.6",
         "@stencil/angular-output-target": "0.8.4",
@@ -25,7 +24,6 @@
         "@types/node": "^20.14.2",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
-        "@types/resize-observer-browser": "^0.1.11",
         "bootstrap": "^5.3.2",
         "chalk": "^5.3.0",
         "execa": "^9.2.0",
@@ -1293,13 +1291,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@juggle/resize-observer": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
-      "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -1754,13 +1745,6 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
-    },
-    "node_modules/@types/resize-observer-browser": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.11.tgz",
-      "integrity": "sha512-cNw5iH8JkMkb3QkCoe7DaZiawbDQEUX8t7iuQaRTyLOyQCR2h+ibBD4GJt7p5yhUHrlOeL7ZtbxNHeipqNsBzQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
   },
   "devDependencies": {
     "@angular/core": "^18.1.2",
-    "@juggle/resize-observer": "^3.4.0",
     "@revolist/stencil-vue2-output-target": "^0.0.6",
     "@revolist/svelte-output-target": "0.0.6",
     "@stencil/angular-output-target": "0.8.4",
@@ -119,7 +118,6 @@
     "@types/node": "^20.14.2",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "@types/resize-observer-browser": "^0.1.11",
     "bootstrap": "^5.3.2",
     "chalk": "^5.3.0",
     "minimist": "^1.2.8",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -5,7 +5,7 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { AdditionalData, AfterEditEvent, AllDimensionType, ApplyFocusEvent, BeforeCellRenderEvent, BeforeEdit, BeforeRangeSaveDataDetails, BeforeRowRenderEvent, BeforeSaveDataDetails, Cell, CellTemplateProp, ChangedRange, ColumnDataSchemaModel, ColumnGrouping, ColumnProp, ColumnRegular, ColumnType, DataFormat, DataType, DimensionCols, DimensionRows, DimensionSettingsState, DimensionType, DimensionTypeCol, DragStartEvent, EditCell, EditorCtr, Editors, ElementScroll, ExtraNodeFuncConfig, FocusAfterRenderEvent, FocusRenderEvent, FocusTemplateFunc, InitialHeaderClick, MultiDimensionType, Nullable, PluginBaseComponent, PositionItem, ProvidersColumns, RangeArea, RangeClipboardCopyEventProps, RangeClipboardPasteEvent, RowDefinition, RowDragStartDetails, RowHeaders, SaveDataDetails, SelectionStoreState, TempRange, Theme, ViewportData, ViewPortResizeEvent, ViewPortScrollEvent, ViewportState, ViewSettingSizeProp } from "./types/index";
+import { AdditionalData, AfterEditEvent, AllDimensionType, ApplyFocusEvent, BeforeCellRenderEvent, BeforeEdit, BeforeRangeSaveDataDetails, BeforeRowRenderEvent, BeforeSaveDataDetails, Cell, CellTemplateProp, ChangedRange, ColumnDataSchemaModel, ColumnGrouping, ColumnProp, ColumnRegular, ColumnType, DataFormat, DataType, DimensionCols, DimensionRows, DimensionSettingsState, DimensionType, DimensionTypeCol, DragStartEvent, EditCell, EditorCtr, Editors, ElementScroll, ExtraNodeFuncConfig, FocusAfterRenderEvent, FocusRenderEvent, FocusTemplateFunc, InitialHeaderClick, MultiDimensionType, Nullable, PluginBaseComponent, PluginProviders, PositionItem, ProvidersColumns, RangeArea, RangeClipboardCopyEventProps, RangeClipboardPasteEvent, RowDefinition, RowDragStartDetails, RowHeaders, SaveDataDetails, SelectionStoreState, TempRange, Theme, ViewportData, ViewPortResizeEvent, ViewPortScrollEvent, ViewportState, ViewSettingSizeProp } from "./types/index";
 import { GridPlugin } from "./plugins/base.plugin";
 import { AutoSizeColumnConfig } from "./plugins/column.auto-size.plugin";
 import { ColumnFilterConfig, FilterCaptions, FilterCollectionItem, LogicFunction, MultiFilterItem, ShowData } from "./plugins/filter/filter.types";
@@ -21,7 +21,7 @@ import { ResizeProps } from "./components/header/resizable.directive";
 import { HeaderRenderProps } from "./components/header/header-renderer";
 import { HeaderGroupRendererProps } from "./components/header/header-group-renderer";
 import { EventData } from "./components/overlay/selection.utils";
-export { AdditionalData, AfterEditEvent, AllDimensionType, ApplyFocusEvent, BeforeCellRenderEvent, BeforeEdit, BeforeRangeSaveDataDetails, BeforeRowRenderEvent, BeforeSaveDataDetails, Cell, CellTemplateProp, ChangedRange, ColumnDataSchemaModel, ColumnGrouping, ColumnProp, ColumnRegular, ColumnType, DataFormat, DataType, DimensionCols, DimensionRows, DimensionSettingsState, DimensionType, DimensionTypeCol, DragStartEvent, EditCell, EditorCtr, Editors, ElementScroll, ExtraNodeFuncConfig, FocusAfterRenderEvent, FocusRenderEvent, FocusTemplateFunc, InitialHeaderClick, MultiDimensionType, Nullable, PluginBaseComponent, PositionItem, ProvidersColumns, RangeArea, RangeClipboardCopyEventProps, RangeClipboardPasteEvent, RowDefinition, RowDragStartDetails, RowHeaders, SaveDataDetails, SelectionStoreState, TempRange, Theme, ViewportData, ViewPortResizeEvent, ViewPortScrollEvent, ViewportState, ViewSettingSizeProp } from "./types/index";
+export { AdditionalData, AfterEditEvent, AllDimensionType, ApplyFocusEvent, BeforeCellRenderEvent, BeforeEdit, BeforeRangeSaveDataDetails, BeforeRowRenderEvent, BeforeSaveDataDetails, Cell, CellTemplateProp, ChangedRange, ColumnDataSchemaModel, ColumnGrouping, ColumnProp, ColumnRegular, ColumnType, DataFormat, DataType, DimensionCols, DimensionRows, DimensionSettingsState, DimensionType, DimensionTypeCol, DragStartEvent, EditCell, EditorCtr, Editors, ElementScroll, ExtraNodeFuncConfig, FocusAfterRenderEvent, FocusRenderEvent, FocusTemplateFunc, InitialHeaderClick, MultiDimensionType, Nullable, PluginBaseComponent, PluginProviders, PositionItem, ProvidersColumns, RangeArea, RangeClipboardCopyEventProps, RangeClipboardPasteEvent, RowDefinition, RowDragStartDetails, RowHeaders, SaveDataDetails, SelectionStoreState, TempRange, Theme, ViewportData, ViewPortResizeEvent, ViewPortScrollEvent, ViewportState, ViewSettingSizeProp } from "./types/index";
 export { GridPlugin } from "./plugins/base.plugin";
 export { AutoSizeColumnConfig } from "./plugins/column.auto-size.plugin";
 export { ColumnFilterConfig, FilterCaptions, FilterCollectionItem, LogicFunction, MultiFilterItem, ShowData } from "./plugins/filter/filter.types";
@@ -153,6 +153,10 @@ export namespace Components {
           * Get all active plugins instances
          */
         "getPlugins": () => Promise<PluginBaseComponent[]>;
+        /**
+          * Get all providers for grid Useful for external grid integration
+         */
+        "getProviders": () => Promise<PluginProviders | undefined>;
         /**
           * Get the currently selected Range.
          */

--- a/src/components/revoGrid/revo-grid.tsx
+++ b/src/components/revoGrid/revo-grid.tsx
@@ -918,6 +918,14 @@ export class RevoGridComponent {
     this.extraService?.refresh();
   }
 
+  /**
+   * Get all providers for grid
+   * Useful for external grid integration
+   */
+  @Method() async getProviders() {
+    return this.getPluginData();
+  }
+
   // #endregion
 
   // #region Listeners outside scope

--- a/src/components/revoGrid/viewport.resize.service.ts
+++ b/src/components/revoGrid/viewport.resize.service.ts
@@ -1,6 +1,4 @@
 import throttle from 'lodash/throttle';
-import { resizeObserver } from '../../utils/resize-observer.polifill';
-
 type ResizeEntry = {
   width: number;
   height: number;
@@ -43,8 +41,7 @@ export default class GridResizeService {
     this.init(el, extras);
   }
 
-  async init(el: HTMLElement, extras: HTMLElement[] = []): Promise<void> {
-    await resizeObserver();
+  init(el: HTMLElement, extras: HTMLElement[] = []) {
     const observer = this.resizeObserver = new ResizeObserver((e) => {
       if (e.length) {
         if (e[0].target === el) {
@@ -60,7 +57,7 @@ export default class GridResizeService {
     });
   }
 
-  public destroy() {
+  destroy() {
     this.resizeObserver?.disconnect();
     this.resizeObserver = null;
   }

--- a/src/components/scroll/revogr-viewport-scroll.tsx
+++ b/src/components/scroll/revogr-viewport-scroll.tsx
@@ -262,6 +262,7 @@ export class RevogrViewportScroll implements ElementScroll {
           this.setScrollVisibility(dimension, item.size, item.contentSize);
         }
       },
+      [this.footer, this.header],
     );
   }
 

--- a/src/utils/resize-observer.polifill.ts
+++ b/src/utils/resize-observer.polifill.ts
@@ -1,6 +1,0 @@
-export async function resizeObserver() {
-  if (!('ResizeObserver' in window)) {
-    const module = await import('@juggle/resize-observer');
-    (window as Window & typeof globalThis).ResizeObserver = (module.ResizeObserver as unknown) as typeof ResizeObserver;
-  }
-}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a public method to retrieve all grid providers, enabling external access to core grid functionalities.
- **Refactor**
	- Enhanced resize handling to observe multiple elements, improving responsiveness to size changes in grid headers and footers.
	- Removed polyfill for resize observer, streamlining dependency management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->