### PR TITLE
Allow number sorting to be correct and not alpha sorting

### DIFF
--- a/src/plugins/sorting/sorting.func.ts
+++ b/src/plugins/sorting/sorting.func.ts
@@ -48,7 +48,7 @@ export function sortIndexByItems(
 export function defaultCellCompare(this: { column?: ColumnRegular }, prop: ColumnProp, a: DataType, b: DataType) {
   const aRaw = this.column ? getCellRaw(a, this.column) : a?.[prop];
   const bRaw = this.column ? getCellRaw(b, this.column) : b?.[prop];
-  const av = typeof bRaw === 'number' ? aRaw : aRaw?.toString().toLowerCase();
+  const av = typeof aRaw === 'number' ? aRaw : aRaw?.toString().toLowerCase();
   const bv = typeof bRaw === 'number' ? bRaw : bRaw?.toString().toLowerCase();
 
   if (av === bv) {


### PR DESCRIPTION
This will be a breaking changing to sorting however it would be more accurate than before. Currently having to write custom compare just so we not always using alpha sort.

Ideally by default we handle boolean, date, datetime, number and string. Happy to add the if you agree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sorting accuracy by correctly handling numbers and strings during comparisons. Numeric values are now compared as numbers, while non-numeric values are compared as lowercase strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->