### PR TITLE
Fix additive sorting

### DIFF
--- a/src/plugins/sorting/sorting.plugin.ts
+++ b/src/plugins/sorting/sorting.plugin.ts
@@ -195,23 +195,24 @@ export class SortingPlugin extends BasePlugin {
       const sorting: SortingOrder = {};
       const sortingFunc: SortingOrderFunction = {};
 
-      this.sorting = {
-        ...this.sorting,
-        ...sorting,
-      };
-      // extend sorting function with new sorting for multiple columns sorting
-      this.sortingFunc = {
-        ...this.sortingFunc,
-        ...sortingFunc,
-      };
-
       if (columnProp in sorting && size(sorting) > 1 && order === undefined) {
         delete sorting[columnProp];
         delete sortingFunc[columnProp];
       } else {
         sorting[columnProp] = order;
         sortingFunc[columnProp] = cmp;
-      }
+      }      
+
+      this.sorting = {
+        ...this.sorting,
+        ...sorting,
+      };
+      
+      // extend sorting function with new sorting for multiple columns sorting
+      this.sortingFunc = {
+        ...this.sortingFunc,
+        ...sortingFunc,
+      };
     } else {
       if (order) {
         // reset sorting


### PR DESCRIPTION
Additive sorting is broken. The new sorting is applied to a local variable merged to the global sorting state before. The reordering of the code fixes adding new sorting functions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal handling of sorting updates for table columns to ensure more consistent behavior when changing sort order. No visible changes to the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->