### PR TITLE
Performance: Fix O(n²) column prop merging in gatherGroup

### DIFF
--- a/src/utils/column.utils.ts
+++ b/src/utils/column.utils.ts
@@ -198,7 +198,7 @@ export function gatherGroup<T extends ColumnCollection>(
       // fill grouping
       const itemLength = collectionItem.length;
       if (itemLength) {
-        const columnLength = [...(existingColumnsByType?.[type] || []), ...resultItem].length;
+        const columnLength = (existingColumnsByType?.[type] || []).length + resultItem.length;
         // fill columns
         resultItem.push(...collectionItem);
 
@@ -221,11 +221,13 @@ export function gatherGroup<T extends ColumnCollection>(
     res.columnGrouping[key].push(...rebasedItem);
   }
   res.maxLevel = Math.max(res.maxLevel, collection.maxLevel);
-  res.sort = { ...res.sort, ...collection.sort };
-  res.columnByProp = {
-    ...res.columnByProp,
-    ...collection.columnByProp,
-  };
+
+  res.sort = res.sort || {};
+  res.columnByProp = res.columnByProp || {};
+
+  Object.assign(res.sort, collection.sort);
+  Object.assign(res.columnByProp, collection.columnByProp);
+
   return res;
 }
 


### PR DESCRIPTION
**Problem**

When using a large number of grouped columns (tens of thousands), the grid experienced significant performance degradation during column collection initialization.

The bottleneck was in gatherGroup (src/utils/column.utils.ts), where columnByProp and sort were
merged using spread syntax:

```
res.columnByProp = { ...res.columnByProp, ...collection.columnByProp };
res.sort = { ...res.sort, ...collection.sort };
```

Each call created a new object by copying all previously accumulated entries plus the new ones.
With recursive group processing, this results in O(n²) total copy operations — profiling showed ~4 seconds spent on this line alone for moderately sized datasets.

**Fix**

Replace spread-based merging with in-place mutation via Object.assign:

```
res.sort = res.sort || {};
res.columnByProp = res.columnByProp || {};

Object.assign(res.columnByProp, collection.columnByProp);
Object.assign(res.sort, collection.sort);
```

Since res is already mutated elsewhere in gatherGroup (array pushes, maxLevel assignment), and collection is a temporary object that is not referenced after the call, this change is safe.
Merge priority is preserved — right-hand side overwrites left, same as spread.

**Result**

Overall complexity drops from O(n²) to O(n): each column prop is written exactly once, with no intermediate object allocations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal column utility functions for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->