### PR TITLE
Fix selected cell focus when pinning a column

### DIFF
--- a/e2e/pinning.spec.ts
+++ b/e2e/pinning.spec.ts
@@ -99,6 +99,153 @@ test.describe('pinning', () => {
     });
   });
 
+  test('keeps focused cell aligned when its column is pinned left', async ({ page }) => {
+    const source = buildRows(8, ['invoice', 'customer', 'status']).map((row, index) => ({
+      invoice: `invoice-${index + 1}`,
+      customer: `Customer ${index + 1}`,
+      status: `Status ${index + 1}`,
+    }));
+
+    await mountGrid(page, {
+      columns: [
+        { prop: 'invoice', name: 'Invoice', size: 150 },
+        { prop: 'customer', name: 'Customer', size: 180 },
+        { prop: 'status', name: 'Status', size: 150 },
+      ],
+      source,
+      width: 520,
+      height: 300,
+      range: true,
+      colSize: 150,
+    });
+
+    await setCellsFocus(page, { x: 1, y: 4 });
+    await expect.poll(() => getSelectedRange(page)).toMatchObject({
+      x: 1,
+      y: 4,
+      x1: 1,
+      y1: 4,
+      colType: 'rgCol',
+      rowType: 'rgRow',
+    });
+
+    await page.evaluate(() => {
+      const grid = document.querySelector<HTMLRevoGridElement>('revo-grid');
+      if (!grid) {
+        throw new Error('Grid element was not found');
+      }
+      grid.columns = [
+        { prop: 'invoice', name: 'Invoice', size: 150 },
+        { prop: 'customer', name: 'Customer', size: 180, pin: 'colPinStart' },
+        { prop: 'status', name: 'Status', size: 150 },
+      ];
+    });
+    await page.waitForChanges();
+
+    await expect(pinnedStartCell(page, 4, 0)).toHaveText('Customer 5');
+    await expect(dataCell(page, 4, 0)).toHaveText('invoice-5');
+    await expect.poll(() => getSelectedRange(page)).toMatchObject({
+      x: 0,
+      y: 4,
+      x1: 0,
+      y1: 4,
+      colType: 'colPinStart',
+      rowType: 'rgRow',
+    });
+
+    const focusedBox = await page.locator(SELECTORS.focusedCell).boundingBox();
+    const pinnedCellBox = await pinnedStartCell(page, 4, 0).boundingBox();
+    expect(focusedBox).not.toBeNull();
+    expect(pinnedCellBox).not.toBeNull();
+    expect(Math.abs(focusedBox!.x - pinnedCellBox!.x)).toBeLessThanOrEqual(2);
+    expect(Math.abs(focusedBox!.y - pinnedCellBox!.y)).toBeLessThanOrEqual(2);
+
+    await page.evaluate(() => {
+      const grid = document.querySelector<HTMLRevoGridElement>('revo-grid');
+      if (!grid) {
+        throw new Error('Grid element was not found');
+      }
+      grid.columns = [
+        { prop: 'invoice', name: 'Invoice', size: 150 },
+        { prop: 'customer', name: 'Customer', size: 180 },
+        { prop: 'status', name: 'Status', size: 150 },
+      ];
+    });
+    await page.waitForChanges();
+
+    await expect(dataCell(page, 4, 0)).toHaveText('invoice-5');
+    await expect(dataCell(page, 4, 1)).toHaveText('Customer 5');
+    await expect(pinnedStartCell(page, 4, 0)).toHaveCount(0);
+    await expect.poll(() => getSelectedRange(page)).toMatchObject({
+      x: 1,
+      y: 4,
+      x1: 1,
+      y1: 4,
+      colType: 'rgCol',
+      rowType: 'rgRow',
+    });
+
+    const unpinnedFocusedBox = await page.locator(SELECTORS.focusedCell).boundingBox();
+    const unpinnedCellBox = await dataCell(page, 4, 1).boundingBox();
+    expect(unpinnedFocusedBox).not.toBeNull();
+    expect(unpinnedCellBox).not.toBeNull();
+    expect(Math.abs(unpinnedFocusedBox!.x - unpinnedCellBox!.x)).toBeLessThanOrEqual(2);
+    expect(Math.abs(unpinnedFocusedBox!.y - unpinnedCellBox!.y)).toBeLessThanOrEqual(2);
+  });
+
+  test('keeps selected range when regular columns refresh without repartitioning', async ({ page }) => {
+    const source = buildRows(5, ['invoice', 'customer', 'status']).map((row, index) => ({
+      invoice: `invoice-${index + 1}`,
+      customer: `Customer ${index + 1}`,
+      status: `Status ${index + 1}`,
+    }));
+
+    await mountGrid(page, {
+      columns: [
+        { prop: 'invoice', name: 'Invoice', size: 150 },
+        { prop: 'customer', name: 'Customer', size: 180 },
+        { prop: 'status', name: 'Status', size: 150 },
+      ],
+      source,
+      width: 520,
+      height: 260,
+      range: true,
+      colSize: 150,
+    });
+
+    await setCellsFocus(page, { x: 0, y: 1 }, { x: 1, y: 3 });
+    await expect.poll(() => getSelectedRange(page)).toMatchObject({
+      x: 0,
+      y: 1,
+      x1: 1,
+      y1: 3,
+      colType: 'rgCol',
+      rowType: 'rgRow',
+    });
+
+    await page.evaluate(() => {
+      const grid = document.querySelector<HTMLRevoGridElement>('revo-grid');
+      if (!grid) {
+        throw new Error('Grid element was not found');
+      }
+      grid.columns = [
+        { prop: 'invoice', name: 'Invoice #', size: 150 },
+        { prop: 'customer', name: 'Customer name', size: 180 },
+        { prop: 'status', name: 'Current status', size: 150 },
+      ];
+    });
+    await page.waitForChanges();
+
+    await expect.poll(() => getSelectedRange(page)).toMatchObject({
+      x: 0,
+      y: 1,
+      x1: 1,
+      y1: 3,
+      colType: 'rgCol',
+      rowType: 'rgRow',
+    });
+  });
+
   test('keeps pinned areas aligned after compressed deep row scroll', async ({ page }) => {
     const rowSize = 30;
     const rowCount = 1_200_000;

--- a/src/components/revoGrid/revo-grid.tsx
+++ b/src/components/revoGrid/revo-grid.tsx
@@ -45,6 +45,7 @@ import type {
   ExtraNodeFuncConfig,
   RowDragStartDetails,
   AdditionalData,
+  PendingColumnFocusRestore,
 } from '@type';
 
 import ColumnDataProvider from '../../services/column.data.provider';
@@ -88,7 +89,6 @@ import { ColumnFilterConfig, FilterCollectionItem } from '../../plugins/filter/f
 import { PluginService } from './plugin.service';
 import { SortingConfig, SortingOrder } from '../../plugins';
 import { RTLPlugin } from '../../plugins/rtl/rtl.plugin';
-
 
 /**
  * Revogrid - High-performance, customizable grid library for managing large datasets.
@@ -1126,6 +1126,7 @@ export class RevoGridComponent {
   orderService: OrdererService;
   selectionStoreConnector?: SelectionStoreConnector;
   scrollingService: GridScrollingService;
+  private pendingColumnFocusRestore?: PendingColumnFocusRestore;
 
   // #endregion
 
@@ -1144,6 +1145,7 @@ export class RevoGridComponent {
     if (!this.dimensionProvider || !this.columnProvider) {
       return;
     }
+    const focusToRestore = init ? undefined : this.getColumnFocusRestore();
     const beforeGatherEvent = this.beforecolumnsgather.emit({
       columns: [...newVal],
     });
@@ -1169,6 +1171,9 @@ export class RevoGridComponent {
       return;
     }
     const columns = this.columnProvider.setColumns(beforeApplyEvent.detail);
+    if (focusToRestore) {
+      this.pendingColumnFocusRestore = focusToRestore;
+    }
     const order: SortingOrder = {};
     for (const prop of Object.keys(beforeApplyEvent.detail.sort)) {
       order[prop] = beforeApplyEvent.detail.sort[prop].order;
@@ -1177,6 +1182,66 @@ export class RevoGridComponent {
       columns,
       order,
     });
+  }
+
+  /**
+   * Capture logical focus before columns are repartitioned by pin state.
+   * Regression case: selecting a regular cell, then pinning that column left,
+   * used to let the new pinned viewport reuse the old rgCol selection store.
+   */
+  private getColumnFocusRestore(): PendingColumnFocusRestore | undefined {
+    const focused = this.viewport?.getFocused();
+    const prevStoreX = this.selectionStoreConnector?.focusedStore?.position.x;
+    const prop = focused?.column?.prop;
+    if (!focused || prop === undefined || prevStoreX === undefined) {
+      return;
+    }
+    return {
+      prop,
+      colType: focused.colType,
+      colIndex: focused.cell.x,
+      prevStoreX,
+      rowType: focused.rowType,
+      rowIndex: focused.cell.y,
+    };
+  }
+
+  /**
+   * Reapply focus by column prop after render, once pinning has moved the
+   * column to its new viewport and virtual index.
+   */
+  private restoreColumnFocusAfterRender() {
+    const pending = this.pendingColumnFocusRestore;
+    if (!pending) {
+      return;
+    }
+    this.pendingColumnFocusRestore = undefined;
+    if (!this.viewport || !this.columnProvider) {
+      return;
+    }
+    const column = this.columnProvider.getColumnByProp(pending.prop)?.[0] ?? getColumnByProp(this.columns, pending.prop);
+    if (!column) {
+      return;
+    }
+    const colType: DimensionCols = column.pin || 'rgCol';
+    const columnIndex = this.columnProvider.getColumnIndexByProp(pending.prop, colType);
+    if (columnIndex < 0) {
+      return;
+    }
+    // Header-only column refreshes should not collapse an existing range.
+    // Replay focus only when pin/unpin or repartitioning moved the logical column.
+    if (
+      colType === pending.colType &&
+      columnIndex === pending.colIndex &&
+      pending.prevStoreX === this.selectionStoreConnector?.focusedStore?.position.x
+    ) {
+      return;
+    }
+    const cell = {
+      x: columnIndex,
+      y: pending.rowIndex,
+    };
+    this.viewport.setFocus(colType, pending.rowType, cell, cell);
   }
 
   @Watch('disableVirtualX') disableVirtualXChanged(
@@ -1580,6 +1645,7 @@ export class RevoGridComponent {
   }
 
   componentDidRender() {
+    this.restoreColumnFocusAfterRender();
     this.aftergridrender.emit();
   }
 

--- a/src/services/selection.store.connector.ts
+++ b/src/services/selection.store.connector.ts
@@ -62,13 +62,11 @@ export class SelectionStoreConnector {
   }
 
   registerColumn(x: number, type: DimensionCols): SelectionStore {
+    this.updateColumnTypeMapping(x, type);
     if (this.columnStores[x]) {
       return this.columnStores[x];
     }
     this.columnStores[x] = new SelectionStore();
-    // build cross-linking type to position
-    this.storesByType[type] = x;
-    this.storesXToType[x] = type;
     return this.columnStores[x];
   }
 
@@ -314,5 +312,33 @@ export class SelectionStoreConnector {
       stores[i] = this.stores[i][x];
     }
     return stores;
+  }
+
+  /**
+   * Keep column viewport positions and types in sync across pin/unpin rerenders.
+   * Regression case: when a selected rgCol cell was pinned left, colPinStart
+   * could take over x=0 and render the stale rgCol focus store in the pinned area.
+   */
+  private updateColumnTypeMapping(x: number, type: DimensionCols) {
+    const previousType = this.storesXToType[x];
+    const previousX = this.storesByType[type];
+    let shouldClearFocus = false;
+
+    this.storesByType[type] = x;
+    this.storesXToType[x] = type;
+
+    if (previousType && previousType !== type) {
+      shouldClearFocus = true;
+      if (this.storesByType[previousType] === x) {
+        delete this.storesByType[previousType];
+      }
+    }
+    if (typeof previousX === 'number' && previousX !== x && this.storesXToType[previousX] === type) {
+      delete this.storesXToType[previousX];
+      shouldClearFocus = true;
+    }
+    if (shouldClearFocus) {
+      this.clearAll();
+    }
   }
 }

--- a/src/types/selection.ts
+++ b/src/types/selection.ts
@@ -80,6 +80,20 @@ export type ChangedRange = {
 };
 
 /**
+ * Logical focus marker captured before column viewport ownership changes.
+ * Used when a selected column is pinned/unpinned so focus can be restored by
+ * column prop after the column moves between rgCol, colPinStart, or colPinEnd.
+ */
+export type PendingColumnFocusRestore = {
+  prop: ColumnProp;
+  colType: DimensionCols;
+  colIndex: ColIndex;
+  prevStoreX: ColIndex;
+  rowType: DimensionRows;
+  rowIndex: RowIndex;
+};
+
+/**
  * Cell coordinates
  */
 export interface Cell {


### PR DESCRIPTION
## Summary
- keep selection store column viewport mappings in sync when pin/unpin changes viewport ownership
- preserve focused cell by column prop across column repartitioning so selected columns can move into pinned viewports cleanly
- add a pinning E2E regression for focusing a regular cell, pinning that column left, and verifying focus alignment in `colPinStart`

## Root Cause
Selection stores are keyed by viewport position. Pinning a selected regular column can make `colPinStart` take over a position previously used by `rgCol`, allowing stale focus/range state to render in the pinned-left area.

Closes #863

## Validation
- `PATH=/opt/homebrew/bin:$PATH pnpm -C revogrid exec stencil build --dev --serve --no-open`
- Targeted Playwright regression passed against built `www` output with a temporary no-webserver config because Stencil watch serve fails locally on Node 24 with `ERR_SOCKET_BAD_PORT`: `pinning › keeps focused cell aligned when its column is pinned left`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Grid preserves and restores the logical focused cell when columns move between pinned and regular positions, maintaining visual alignment after pin/unpin.

* **Bug Fixes**
  * Selection stability improved so focus and selected ranges persist correctly across pin/unpin and when column metadata is refreshed, preventing stale focus or misaligned selection.

* **Tests**
  * Added end-to-end tests validating focus alignment, selection type changes, and selected-range stability after pinning/unpinning and column refreshes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/revolist/revogrid/pull/864?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->