### PR TITLE
fix/last row issue for 1mln row offset

### DIFF
--- a/e2e/virtualization.spec.ts
+++ b/e2e/virtualization.spec.ts
@@ -159,6 +159,164 @@ test.describe('virtualization', () => {
     expect(Math.abs(cellBox!.y - focusBox!.y)).toBeLessThan(2);
   });
 
+  test('keeps the final compressed-scroll row inside the viewport', async ({ page }) => {
+    const rowSize = 46;
+    const lastRowSize = 80;
+    const rowCount = 1_000_000;
+    const lastRow = rowCount - 1;
+
+    await page.setContent(`
+      <div style="width:760px; height:360px;">
+        <revo-grid style="display:block; width:100%; height:100%;"></revo-grid>
+      </div>
+    `);
+    await page.waitForSelector(SELECTORS.grid);
+    await page.evaluate(({ lastRowSize, rowCount, rowSize }) => {
+      const grid = document.querySelector<HTMLRevoGridElement>('revo-grid');
+      if (!grid) {
+        throw new Error('Grid element was not created');
+      }
+      grid.columns = [
+        { prop: 'c0', name: 'A', size: 170 },
+        { prop: 'c1', name: 'B', size: 170 },
+      ];
+      grid.source = Array.from({ length: rowCount }, (_, rowIndex) => ({
+        c0: `${rowIndex}:0`,
+        c1: `${rowIndex}:1`,
+      }));
+      grid.rowHeaders = true;
+      grid.rowDefinitions = [{
+        type: 'rgRow',
+        index: rowCount - 1,
+        size: lastRowSize,
+      }];
+      grid.rowSize = rowSize;
+    }, { lastRowSize, rowCount, rowSize });
+    await page.waitForChanges();
+    await expect.poll(() => mainDataRows(page).count()).toBeGreaterThan(0);
+
+    const logicalContentSize = await callGridMethod<{ y: number }>(page, 'getContentSize');
+    const physicalScrollHeight = await page
+      .locator(`${SELECTORS.mainViewport} .vertical-inner`)
+      .evaluate((el: HTMLElement) => el.scrollHeight);
+    expect(physicalScrollHeight).toBeLessThan(logicalContentSize.y);
+
+    await callGridMethod(page, 'scrollToRow', lastRow);
+    await page.waitForChanges();
+    await expect(dataCell(page, lastRow, 0)).toHaveText(`${lastRow}:0`);
+
+    const boxes = await page.evaluate(({ viewportSelector, cellSelector }) => {
+      const viewport = document.querySelector<HTMLElement>(viewportSelector);
+      const cell = document.querySelector<HTMLElement>(cellSelector);
+      if (!viewport || !cell) {
+        throw new Error('Expected viewport and final-row cell to be rendered');
+      }
+      const viewportBox = viewport.getBoundingClientRect();
+      const cellBox = cell.getBoundingClientRect();
+      return {
+        viewportBottom: viewportBox.bottom,
+        cellBottom: cellBox.bottom,
+      };
+    }, {
+      viewportSelector: `${SELECTORS.mainViewport} .vertical-inner`,
+      cellSelector: `${SELECTORS.mainViewport} revogr-data[type="rgRow"] [data-rgrow="${lastRow}"] [data-rgcol="0"]`,
+    });
+    expect(boxes.cellBottom).toBeLessThanOrEqual(boxes.viewportBottom + 1);
+    const lastRowBox = await page
+      .locator(`${SELECTORS.mainViewport} revogr-data[type="rgRow"] .rgRow[data-rgrow="${lastRow}"]`)
+      .boundingBox();
+    expect(lastRowBox).not.toBeNull();
+    expect(lastRowBox!.height).toBe(lastRowSize);
+
+    await setCellsFocus(page, { x: 0, y: lastRow });
+    await expect.poll(() => getFocused(page)).toMatchObject({
+      cell: { x: 0, y: lastRow },
+    });
+    const cellBox = await dataCell(page, lastRow, 0).boundingBox();
+    const focusBox = await page.locator(SELECTORS.focusedCell).boundingBox();
+    expect(cellBox).not.toBeNull();
+    expect(focusBox).not.toBeNull();
+    expect(Math.abs(cellBox!.x - focusBox!.x)).toBeLessThanOrEqual(2);
+    expect(Math.abs(cellBox!.y - focusBox!.y)).toBeLessThanOrEqual(2);
+    expect(focusBox!.y + focusBox!.height).toBeLessThanOrEqual(boxes.viewportBottom + 1);
+  });
+
+  test('keeps the final compressed-scroll column inside the viewport', async ({ page }) => {
+    const colSize = 300;
+    const colCount = 120_000;
+    const lastColumn = colCount - 1;
+
+    await page.setContent(`
+      <div style="width:780px; height:260px;">
+        <revo-grid style="display:block; width:100%; height:100%;"></revo-grid>
+      </div>
+    `);
+    await page.waitForSelector(SELECTORS.grid);
+    await page.evaluate(({ colCount, colSize }) => {
+      const grid = document.querySelector<HTMLRevoGridElement>('revo-grid');
+      if (!grid) {
+        throw new Error('Grid element was not created');
+      }
+      const cellParser = (model: Record<string, string | number>, column: { prop: string }) =>
+        model[column.prop] ?? `Row ${model.row} ${column.prop}`;
+      grid.columns = Array.from({ length: colCount }, (_, index) => ({
+        prop: `c${index}`,
+        name: `C ${index}`,
+        size: colSize,
+        cellParser,
+      }));
+      grid.source = [{ row: 1, [`c${colCount - 1}`]: `Row 1 c${colCount - 1}` }];
+      grid.colSize = colSize;
+    }, { colCount, colSize });
+    await page.waitForChanges();
+    await expect.poll(() => mainDataRows(page).count()).toBeGreaterThan(0);
+
+    const logicalContentSize = await callGridMethod<{ x: number }>(page, 'getContentSize');
+    const physicalScrollWidth = await page
+      .locator(SELECTORS.mainViewport)
+      .evaluate((el: HTMLElement) => el.scrollWidth);
+    expect(physicalScrollWidth).toBeLessThan(logicalContentSize.x);
+
+    await callGridMethod(page, 'scrollToColumnIndex', lastColumn);
+    await page.waitForChanges();
+    await expect(dataCell(page, 0, lastColumn)).toHaveText(`Row 1 c${lastColumn}`);
+
+    const boxes = await page.evaluate(({ viewportSelector, cellSelector }) => {
+      const viewport = document.querySelector<HTMLElement>(viewportSelector);
+      const cell = document.querySelector<HTMLElement>(cellSelector);
+      if (!viewport || !cell) {
+        throw new Error('Expected viewport and final-column cell to be rendered');
+      }
+      const viewportBox = viewport.getBoundingClientRect();
+      const cellBox = cell.getBoundingClientRect();
+      return {
+        viewportRight: viewportBox.right,
+        cellRight: cellBox.right,
+      };
+    }, {
+      viewportSelector: SELECTORS.mainViewport,
+      cellSelector: `${SELECTORS.mainViewport} revogr-data[type="rgRow"] [data-rgrow="0"] [data-rgcol="${lastColumn}"]`,
+    });
+    expect(boxes.cellRight).toBeLessThanOrEqual(boxes.viewportRight + 1);
+
+    const cell = dataCell(page, 0, lastColumn);
+    const cellBox = await cell.boundingBox();
+    expect(cellBox).not.toBeNull();
+    await page.mouse.click(
+      cellBox!.x + cellBox!.width / 2,
+      cellBox!.y + cellBox!.height / 2,
+    );
+    await page.waitForChanges();
+    await expect.poll(() => getFocused(page)).toMatchObject({
+      cell: { x: lastColumn, y: 0 },
+    });
+    const focusBox = await page.locator(SELECTORS.focusedCell).boundingBox();
+    expect(focusBox).not.toBeNull();
+    expect(Math.abs(cellBox!.x - focusBox!.x)).toBeLessThanOrEqual(2);
+    expect(Math.abs(cellBox!.y - focusBox!.y)).toBeLessThanOrEqual(2);
+    expect(focusBox!.x + focusBox!.width).toBeLessThanOrEqual(boxes.viewportRight + 1);
+  });
+
   test('maps native physical scroll and wheel deltas to logical vertical coordinates', async ({ page }) => {
     const rowSize = 30;
     const rowCount = 1_200_000;

--- a/src/services/dimension.provider.ts
+++ b/src/services/dimension.provider.ts
@@ -11,7 +11,6 @@ import {
   DimensionStoreCollection,
   gatherTrimmedItems,
   Trimmed,
-  clampViewportCoordinate,
 } from '@store';
 import type {
   DimensionCols,
@@ -221,11 +220,20 @@ export default class DimensionProvider {
       clientSize,
       virtualSize: viewportSize,
     });
-    const renderCoordinate = clampViewportCoordinate(
-      coordinate,
-      dimension,
-      viewportSize,
-    );
+    // Render offset must use the true logical scroll coordinate
+    // It is the logical scroll position that should be used for compressed-scroll offset math.
+    const renderCoordinate = Math.min(
+      Math.max(0, coordinate), // prevents negative scroll positions
+      scrollDimension.logicalScrollSize,
+    ); // prevents positions past the logical end
+
+
+    /**
+     * If viewport sizing is initialized (clientSize and viewportSize are truthy), calculate the offset needed for compressed scroll.
+     * Otherwise keep renderOffset at 0, because there is not enough measurement data yet.
+     * 
+     * In normal scrolling, logical and physical coordinates are the same, so offset is 0.
+     */
     const renderOffset =
       clientSize && viewportSize
         ? scrollDimension.getRenderOffset(renderCoordinate)

--- a/src/services/scroll.dimension.helpers.ts
+++ b/src/services/scroll.dimension.helpers.ts
@@ -11,11 +11,30 @@ export type ScrollDimensionInput = {
 };
 
 export type ScrollDimension = {
+  /**
+   * Real logical grid content size
+   * e.g. 1_000_000 rows * 46px = 46_000_000px.
+   */
   contentSize: number;
+  /**
+   * Visible viewport size provided by the browser
+   * e.g. 600px height of the scrollable container.
+   */
   clientSize: number;
   viewportSize: number;
+  /**
+   * Fake DOM scrollable size that RevoGrid gives the browser scrollbar.
+   * Grid maps between physical scrollbar coordinates and logical grid coordinates so rows still represent the full dataset.
+   */
   physicalContentSize: number;
+  /**
+   * How far the grid should be scrollable logically.
+   * contentSize - viewportSize, meaning the largest valid logical scroll coordinate.
+   */
   logicalScrollSize: number;
+  /**
+   * How far the browser scrollbar can actually move.
+   */
   physicalScrollSize: number;
   isCompressed: boolean;
   toLogicalCoordinate(coordinate: number): number;

--- a/src/store/vp/viewport.helpers.ts
+++ b/src/store/vp/viewport.helpers.ts
@@ -35,6 +35,29 @@ export function getViewportMaxCoordinate(
   );
 }
 
+/**
+ * Clamp the viewport coordinate within the valid range.
+ * Given a scroll position, pick a safe starting point for rendering visible items.
+ * 
+ * Do not use it when you need the exact scroll position for positioning math.
+ * 
+ * It does two things:
+ * 1. If the coordinate is below 0, use 0.
+ * 2. If the coordinate is too close to the very end, pull it back a bit.
+ * 
+ * Example:
+ *
+ * content height: 1000px
+ * viewport height: 200px
+ * row height: 30px
+ * The real max scroll is:
+ *
+ * 1000 - 200 = 800
+ * But clampViewportCoordinate may clamp to:
+ *
+ * 1000 - 200 - 30 = 770
+ * Ask for 800 -> it returns 770.
+ */
 export function clampViewportCoordinate(
   coordinate: number,
   dimension: Pick<DimensionSettingsState, 'realSize' | 'originItemSize'>,

--- a/test/scroll.dimension.spec.ts
+++ b/test/scroll.dimension.spec.ts
@@ -270,6 +270,113 @@ describe('browser-limit-aware scroll dimensions', () => {
     expect(rowDimension.store.get('renderOffset')).toBe(renderOffset);
   });
 
+  it('uses the actual logical bottom coordinate for compressed render offset', () => {
+    const viewports = new ViewportProvider();
+    const dimensions = new DimensionProvider(viewports, {
+      realSizeChanged: () => undefined,
+    });
+    const rowDimension = dimensions.stores.rgRow;
+    rowDimension.setStore({
+      count: 2_000_000,
+      originItemSize: 30,
+      realSize: 60_000_000,
+    });
+    viewports.stores.rgRow.setViewport({
+      clientSize: 600,
+      virtualSize: 600,
+      realCount: 2_000_000,
+    });
+    const scrollDimension = getScrollDimension({
+      contentSize: 60_000_000,
+      clientSize: 600,
+      virtualSize: 600,
+    });
+
+    dimensions.setViewPortCoordinate({
+      type: 'rgRow',
+      coordinate: scrollDimension.logicalScrollSize,
+    });
+
+    const renderOffset = viewports.stores.rgRow.store.get('renderOffset');
+    expect(renderOffset).toBe(
+      scrollDimension.getRenderOffset(scrollDimension.logicalScrollSize),
+    );
+    expect(rowDimension.store.get('renderOffset')).toBe(renderOffset);
+  });
+
+  it('uses the actual logical bottom coordinate with a custom-sized tail row', () => {
+    const viewports = new ViewportProvider();
+    const dimensions = new DimensionProvider(viewports, {
+      realSizeChanged: () => undefined,
+    });
+    const rowDimension = dimensions.stores.rgRow;
+    const rowCount = 2_000_000;
+    const lastRow = rowCount - 1;
+    rowDimension.setStore({
+      count: rowCount,
+      originItemSize: 30,
+    });
+    rowDimension.setDimensionSize({
+      [lastRow]: 80,
+    });
+    viewports.stores.rgRow.setViewport({
+      clientSize: 600,
+      virtualSize: 600,
+      realCount: rowCount,
+    });
+    const scrollDimension = getScrollDimension({
+      contentSize: rowDimension.store.get('realSize'),
+      clientSize: 600,
+      virtualSize: 600,
+    });
+
+    dimensions.setViewPortCoordinate({
+      type: 'rgRow',
+      coordinate: scrollDimension.logicalScrollSize,
+    });
+
+    const renderOffset = viewports.stores.rgRow.store.get('renderOffset');
+    expect(rowDimension.store.get('realSize')).toBe(60_000_050);
+    expect(renderOffset).toBe(
+      scrollDimension.getRenderOffset(scrollDimension.logicalScrollSize),
+    );
+    expect(rowDimension.store.get('renderOffset')).toBe(renderOffset);
+  });
+
+  it('uses the actual logical right edge coordinate for compressed column render offset', () => {
+    const viewports = new ViewportProvider();
+    const dimensions = new DimensionProvider(viewports, {
+      realSizeChanged: () => undefined,
+    });
+    const colDimension = dimensions.stores.rgCol;
+    colDimension.setStore({
+      count: 120_000,
+      originItemSize: 300,
+      realSize: 36_000_000,
+    });
+    viewports.stores.rgCol.setViewport({
+      clientSize: 780,
+      virtualSize: 780,
+      realCount: 120_000,
+    });
+    const scrollDimension = getScrollDimension({
+      contentSize: 36_000_000,
+      clientSize: 780,
+      virtualSize: 780,
+    });
+
+    dimensions.setViewPortCoordinate({
+      type: 'rgCol',
+      coordinate: scrollDimension.logicalScrollSize,
+    });
+
+    const renderOffset = viewports.stores.rgCol.store.get('renderOffset');
+    expect(renderOffset).toBe(
+      scrollDimension.getRenderOffset(scrollDimension.logicalScrollSize),
+    );
+    expect(colDimension.store.get('renderOffset')).toBe(renderOffset);
+  });
+
   it('recomputes render offset when viewport size changes', () => {
     const firstRenderOffset = getScrollDimension({
       contentSize: 60_000_000,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests covering final-row/column behavior when scrolling to the end of very large grids, verifying rendering, viewport bounds, and focus alignment.
  * Added unit tests verifying scroll-dimension and render-offset calculations for compressed row/column rendering.

* **Bug Fixes**
  * Improved scroll coordinate handling to ensure accurate viewport positioning and render offsets in compressed-scroll scenarios.

* **Documentation**
  * Enhanced inline documentation for scroll-dimension and viewport coordinate behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/revolist/revogrid/pull/874?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->