### PR TITLE
fix/#746

### DIFF
--- a/e2e/layout.spec.ts
+++ b/e2e/layout.spec.ts
@@ -16,6 +16,12 @@ test.describe('layout', () => {
     const columns = [
       { prop: 'id', name: 'ID', ...withHeaderTestId('inactive-header-id') },
       { prop: 'name', name: 'Name', ...withHeaderTestId('inactive-header-name') },
+      {
+        prop: 'role',
+        name: 'Role',
+        order: 'asc',
+        ...withHeaderTestId('ordered-header-role'),
+      },
     ];
 
     await mountGrid(page, {
@@ -29,6 +35,12 @@ test.describe('layout', () => {
     await expect(inactiveHeader.locator('.sort-off')).toHaveCount(0);
     await expect(inactiveHeader.locator('.no-resize')).toHaveCount(0);
     await expect(inactiveHeader.locator('.resizable')).toHaveCount(0);
+
+    const orderedHeader = page.getByTestId('ordered-header-role');
+    await expect(orderedHeader.locator('.sort-indicator')).toHaveCount(1);
+    await expect(orderedHeader.locator('.sort-indicator .asc')).toHaveCount(1);
+    await expect(orderedHeader.locator('.sort-off')).toHaveCount(0);
+    await expect(orderedHeader.locator('.no-resize')).toHaveCount(0);
 
     await mountGrid(page, {
       columns: [

--- a/e2e/layout.spec.ts
+++ b/e2e/layout.spec.ts
@@ -12,6 +12,44 @@ import {
 } from './helpers';
 
 test.describe('layout', () => {
+  test('does not render inactive header sort or resize affordances', async ({ page }) => {
+    const columns = [
+      { prop: 'id', name: 'ID', ...withHeaderTestId('inactive-header-id') },
+      { prop: 'name', name: 'Name', ...withHeaderTestId('inactive-header-name') },
+    ];
+
+    await mountGrid(page, {
+      columns,
+      source: SAMPLE_ROWS.pair,
+      resize: false,
+    });
+
+    const inactiveHeader = page.getByTestId('inactive-header-name');
+    await expect(inactiveHeader.locator('.sort-indicator')).toHaveCount(0);
+    await expect(inactiveHeader.locator('.sort-off')).toHaveCount(0);
+    await expect(inactiveHeader.locator('.no-resize')).toHaveCount(0);
+    await expect(inactiveHeader.locator('.resizable')).toHaveCount(0);
+
+    await mountGrid(page, {
+      columns: [
+        {
+          prop: 'id',
+          name: 'ID',
+          sortable: true,
+          ...withHeaderTestId('active-header-id'),
+        },
+      ],
+      source: SAMPLE_ROWS.pair,
+      resize: true,
+    });
+
+    const activeHeader = page.getByTestId('active-header-id');
+    await expect(activeHeader.locator('.sort-indicator')).toHaveCount(1);
+    await expect(activeHeader.locator('.sort-off')).toHaveCount(1);
+    await expect(activeHeader.locator('.resizable-r')).toHaveCount(1);
+    await expect(activeHeader.locator('.no-resize')).toHaveCount(0);
+  });
+
   test('resizes a column and keeps header and cell widths aligned', async ({ page }) => {
     const columns = [
       { prop: 'id', name: 'ID' },

--- a/src/components/header/header-renderer.tsx
+++ b/src/components/header/header-renderer.tsx
@@ -37,6 +37,11 @@ type KeyedResizableElementHTMLAttributes = ResizableElementHTMLAttributes & {
 };
 
 const HeaderRenderer = (p: HeaderRenderProps): ReturnType<typeof h> => {
+  const hasSortingSign = !!(
+    p.data?.sortable ||
+    p.data?.order ||
+    p.data?.sortIndex
+  );
   const cellClass: { [key: string]: boolean } = {
     [HEADER_CLASS]: true,
     [HEADER_SORTABLE_CLASS]: !!p.data?.sortable,
@@ -90,7 +95,7 @@ const HeaderRenderer = (p: HeaderRenderProps): ReturnType<typeof h> => {
       props={dataProps}
       additionalData={p.additionalData}
     >
-      {p.data?.sortable ? <SortingSign column={p.data} /> : null}
+      {hasSortingSign ? <SortingSign column={p.data} /> : null}
       {p.canFilter && p.data?.filter !== false ? (
         <FilterButton column={p.data} />
       ) : (

--- a/src/components/header/header-renderer.tsx
+++ b/src/components/header/header-renderer.tsx
@@ -90,7 +90,7 @@ const HeaderRenderer = (p: HeaderRenderProps): ReturnType<typeof h> => {
       props={dataProps}
       additionalData={p.additionalData}
     >
-      {<SortingSign column={p.data} />}
+      {p.data?.sortable ? <SortingSign column={p.data} /> : null}
       {p.canFilter && p.data?.filter !== false ? (
         <FilterButton column={p.data} />
       ) : (

--- a/src/components/header/resizable.element.tsx
+++ b/src/components/header/resizable.element.tsx
@@ -22,36 +22,20 @@ export const ResizableElement: FunctionalComponent = (
       })) ||
     null;
 
-  if (props.active) {
-    if (props.canResize) {
-      for (let p in props.active) {
-        resizeEls.push(
-          <div
-            onClick={e => e.preventDefault()}
-            onDblClick={e => {
-              e.preventDefault();
-              props.onDblClick?.(e);
-            }}
-            onMouseDown={(e: MouseEvent) => directive?.handleDown(e)}
-            onTouchStart={(e: TouchEvent) => directive?.handleDown(e)}
-            class={`resizable resizable-${props.active[p]}`}
-          />,
-        );
-      }
-    } else {
-      for (let _p in props.active) {
-        resizeEls.push(
-          <div
-            onClick={e => e.preventDefault()}
-            onTouchStart={(e: TouchEvent) => e.preventDefault()}
-            onDblClick={e => {
-              e.preventDefault();
-              props.onDblClick?.(e);
-            }}
-            class={`no-resize`}
-          />,
-        );
-      }
+  if (props.active && props.canResize) {
+    for (let p in props.active) {
+      resizeEls.push(
+        <div
+          onClick={e => e.preventDefault()}
+          onDblClick={e => {
+            e.preventDefault();
+            props.onDblClick?.(e);
+          }}
+          onMouseDown={(e: MouseEvent) => directive?.handleDown(e)}
+          onTouchStart={(e: TouchEvent) => directive?.handleDown(e)}
+          class={`resizable resizable-${props.active[p]}`}
+        />,
+      );
     }
   }
   return (


### PR DESCRIPTION
Closes #746

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sorting indicators now only appear for headers with an active sorting state.
  * Resize handles are shown only when resizing is enabled for a header.

* **Tests**
  * Added end-to-end test verifying header sorting indicators and resize affordances render correctly under different configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/revolist/revogrid/pull/875?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->