### PR TITLE
feat(filter): reorder filter panel conditions

### DIFF
--- a/e2e/filtering.spec.ts
+++ b/e2e/filtering.spec.ts
@@ -39,6 +39,7 @@ test.describe('filtering', () => {
     const filterPanel = page.locator(SELECTORS.filterPanel);
     await expect(filterPanel).toBeVisible();
     await filterPanel.getByRole('combobox').selectOption({ label: 'Contains' });
+    await expect(filterPanel.locator('.reorder-button')).toHaveCount(0);
     await page.locator(SELECTORS.filterInput).fill('Admin');
 
     await expectVisibleColumnValues(page, 1, ['Alice', 'Cara']);
@@ -105,6 +106,7 @@ test.describe('filtering', () => {
 
     const row = filterPanel.locator('.multi-filter-list-row').first();
     await expect(row).toBeVisible();
+    await expect(row.locator(':scope > .reorder-button')).toHaveCount(1);
     await expect(row.locator(':scope > .select-input')).toHaveCount(1);
     await expect(row.locator(':scope > .multi-filter-list-action')).toHaveCount(1);
     await expect(row.locator('.select-input .multi-filter-list-action')).toHaveCount(0);
@@ -127,6 +129,74 @@ test.describe('filtering', () => {
       );
     });
     expect(isSingleRow).toBe(true);
+  });
+
+  test('reorders filter conditions with the drag handle', async ({ page }) => {
+    const source: SampleRow[] = [
+      { id: 501, name: 'Alice', role: 'Admin', city: 'Lisbon' },
+      { id: 502, name: 'Ben', role: 'Engineer', city: 'Porto' },
+    ];
+
+    const columns = buildColumns([
+      { prop: 'id', name: 'ID' },
+      { prop: 'name', name: 'Name' },
+      { prop: 'role', name: 'Role', filter: true, ...withHeaderTestId('reorder-filter-role') },
+      { prop: 'city', name: 'City' },
+    ]);
+
+    await mountGrid(page, { columns, source, filter: true });
+
+    await page
+      .getByTestId('reorder-filter-role')
+      .locator(SELECTORS.filterButton)
+      .click();
+
+    const filterPanel = page.locator(SELECTORS.filterPanel);
+    const filterInputs = page.locator(SELECTORS.filterInput);
+    await expect(filterPanel).toBeVisible();
+    await filterPanel.getByRole('combobox').selectOption({ label: 'Contains' });
+    await filterInputs.fill('Admin');
+    await filterPanel.locator('#add-filter').selectOption({ label: 'Equal' });
+    await filterInputs.nth(1).fill('Engineer');
+
+    await expect(filterPanel.locator('.multi-filter-list-row')).toHaveCount(2);
+    await expect(filterPanel.locator('.select-filter').nth(0)).toHaveValue('contains');
+    await expect(filterPanel.locator('.select-filter').nth(1)).toHaveValue('eq');
+
+    await filterPanel.evaluate((panel) => {
+      const rows = Array.from(panel.querySelectorAll('.multi-filter-list-row'));
+      const sourceHandle = rows[1].querySelector('.reorder-button');
+      const targetHandle = rows[0].querySelector('.reorder-button');
+      if (!sourceHandle || !targetHandle) {
+        throw new Error('Filter reorder controls were not found');
+      }
+      const dataTransfer = new DataTransfer();
+      sourceHandle.dispatchEvent(new DragEvent('dragstart', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+      }));
+      targetHandle.dispatchEvent(new DragEvent('dragover', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+      }));
+      targetHandle.dispatchEvent(new DragEvent('drop', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+      }));
+      sourceHandle.dispatchEvent(new DragEvent('dragend', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+      }));
+    });
+
+    await expect(filterPanel.locator('.select-filter').nth(0)).toHaveValue('eq');
+    await expect(filterPanel.locator('.select-filter').nth(1)).toHaveValue('contains');
+    await expect(filterInputs.nth(0)).toHaveValue('Engineer');
+    await expect(filterInputs.nth(1)).toHaveValue('Admin');
   });
 
   test('reapplies active filters after source replacement', async ({ page }) => {

--- a/src/plugins/filter/filter.button.tsx
+++ b/src/plugins/filter/filter.button.tsx
@@ -7,6 +7,7 @@ export const FILTER_BUTTON_ACTIVE = 'active';
 export const FILTER_PROP = 'hasFilter';
 export const AND_OR_BUTTON = 'and-or-button';
 export const TRASH_BUTTON = 'trash-button';
+export const REORDER_BUTTON = 'reorder-button';
 
 type Props = {
   column: ColumnRegular;
@@ -41,6 +42,54 @@ export const TrashButton = () => {
 };
 export const AndOrButton = ({ text }: any) => {
   return <button class={{ [AND_OR_BUTTON]: true, 'light revo-button': true }}>{text}</button>;
+};
+
+type ReorderButtonProps = {
+  dragging?: boolean;
+  dragOver?: boolean;
+  onDragStart?: (event: DragEvent) => void;
+  onDragEnd?: (event: DragEvent) => void;
+  onDragOver?: (event: DragEvent) => void;
+  onDragLeave?: (event: DragEvent) => void;
+  onDrop?: (event: DragEvent) => void;
+};
+
+export const ReorderButton = ({
+  dragging,
+  dragOver,
+  onDragStart,
+  onDragEnd,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+}: ReorderButtonProps) => {
+  const applyClass = (el?: HTMLButtonElement) => {
+    if (!el) {
+      return;
+    }
+    el.className = [
+      REORDER_BUTTON,
+      dragging ? 'filter-row-dragging' : '',
+      dragOver ? 'filter-row-drag-over' : '',
+    ].filter(Boolean).join(' ');
+  };
+
+  return (
+    <button
+      type="button"
+      ref={applyClass}
+      draggable={true}
+      title="Reorder filter"
+      aria-label="reorder filter"
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
+    >
+      ::
+    </button>
+  );
 };
 
 export function isFilterBtn(e: HTMLElement) {

--- a/src/plugins/filter/filter.panel.tsx
+++ b/src/plugins/filter/filter.panel.tsx
@@ -15,7 +15,7 @@ import {
 } from '@stencil/core';
 import debounce from 'lodash/debounce';
 
-import { AndOrButton, isFilterBtn, TrashButton } from './filter.button';
+import { AndOrButton, isFilterBtn, ReorderButton, TrashButton } from './filter.button';
 import '../../utils/closest.polifill';
 import {
   FilterCaptions,
@@ -25,6 +25,11 @@ import {
 } from './filter.types';
 import type { ColumnProp } from '@type';
 import { FilterType } from './filter.indexed';
+import {
+  getFilterReorderId,
+  moveFilterItem,
+  setFilterReorderData,
+} from './filter.reorder';
 
 const defaultType: FilterType = 'none';
 
@@ -63,6 +68,8 @@ export class FilterPanel {
   @State() currentFilterType: FilterType = defaultType;
   @State() changes: ShowData | undefined;
   @State() filterItems: MultiFilterItem = {};
+  @State() draggedFilterId: number | undefined;
+  @State() dragOverFilterId: number | undefined;
   @Prop() filterNames: Record<string, string> = {};
   @Prop() filterEntities: Record<string, LogicFunction> = {};
   @Prop() filterCaptions: Partial<FilterCaptions> | undefined;
@@ -137,6 +144,7 @@ export class FilterPanel {
     if (typeof prop === 'undefined') return '';
 
     const propFilters = this.filterItems[prop] ?? [];
+    const visibleFilterCount = propFilters.filter(filter => !filter.hidden).length;
     const capts = Object.assign(
       this.filterCaptionsInternal,
       this.filterCaptions,
@@ -164,7 +172,18 @@ export class FilterPanel {
 
           return (
             <div key={filter.id} class={FILTER_LIST_CLASS}>
-              <div class="multi-filter-list-row">
+              <div ref={el => el?.classList.add('multi-filter-list-row')}>
+                {visibleFilterCount > 1 ? (
+                  <ReorderButton
+                    dragging={this.draggedFilterId === filter.id}
+                    dragOver={this.dragOverFilterId === filter.id && this.draggedFilterId !== filter.id}
+                    onDragStart={e => this.onFilterDragStart(e, filter.id)}
+                    onDragEnd={() => this.onFilterDragEnd()}
+                    onDragOver={e => this.onFilterDragOver(e, filter.id)}
+                    onDragLeave={() => this.onFilterDragLeave(filter.id)}
+                    onDrop={e => this.onFilterDrop(e, prop, filter.id)}
+                  />
+                ) : ''}
                 <div class={{ 'select-input': true }}>
                   <select
                     class="select-css select-filter"
@@ -324,6 +343,58 @@ export class FilterPanel {
     if (!this.disableDynamicFiltering) {
       this.debouncedApplyFilter();
     }
+  }
+
+  private onFilterDragStart(e: DragEvent, id: number) {
+    this.draggedFilterId = id;
+    setFilterReorderData(e.dataTransfer, id);
+  }
+
+  private onFilterDragOver(e: DragEvent, id: number) {
+    if (this.draggedFilterId === undefined || this.draggedFilterId === id) {
+      return;
+    }
+    e.preventDefault();
+    if (e.dataTransfer) {
+      e.dataTransfer.dropEffect = 'move';
+    }
+    this.dragOverFilterId = id;
+  }
+
+  private onFilterDragLeave(id: number) {
+    if (this.dragOverFilterId === id) {
+      this.dragOverFilterId = undefined;
+    }
+  }
+
+  private onFilterDrop(e: DragEvent, prop: ColumnProp, targetId: number) {
+    e.preventDefault();
+    const sourceId = this.draggedFilterId ?? getFilterReorderId(e.dataTransfer);
+    this.onFilterDragEnd();
+
+    if (sourceId === undefined) {
+      return;
+    }
+
+    const items = this.filterItems[prop];
+    if (!items) {
+      return;
+    }
+
+    if (!moveFilterItem(items, sourceId, targetId)) {
+      return;
+    }
+
+    this.filterId++;
+
+    if (!this.disableDynamicFiltering) {
+      this.debouncedApplyFilter();
+    }
+  }
+
+  private onFilterDragEnd() {
+    this.draggedFilterId = undefined;
+    this.dragOverFilterId = undefined;
   }
 
   private toggleFilterAndOr(id: number) {

--- a/src/plugins/filter/filter.reorder.ts
+++ b/src/plugins/filter/filter.reorder.ts
@@ -1,0 +1,47 @@
+import type { FilterData } from './filter.types';
+
+const FILTER_REORDER_MIME = 'text/revogrid-filter-id';
+
+export function setFilterReorderData(dataTransfer: DataTransfer | null, id: number) {
+  if (!dataTransfer) {
+    return;
+  }
+  dataTransfer.effectAllowed = 'move';
+  dataTransfer.setData(FILTER_REORDER_MIME, String(id));
+  dataTransfer.setData('text/plain', String(id));
+}
+
+export function getFilterReorderId(dataTransfer: DataTransfer | null): number | undefined {
+  if (!dataTransfer) {
+    return;
+  }
+  const rawId = dataTransfer.getData(FILTER_REORDER_MIME) || dataTransfer.getData('text/plain');
+  const normalizedId = rawId.trim();
+  if (!normalizedId) {
+    return;
+  }
+  const id = Number(normalizedId);
+  return Number.isFinite(id) ? id : undefined;
+}
+
+export function moveFilterItem(items: FilterData[], sourceId: number, targetId: number): boolean {
+  if (sourceId === targetId) {
+    return false;
+  }
+
+  const sourceIndex = items.findIndex(item => item.id === sourceId);
+  const targetIndex = items.findIndex(item => item.id === targetId);
+  if (sourceIndex === -1 || targetIndex === -1 || sourceIndex === targetIndex) {
+    return false;
+  }
+
+  const relationsByPosition = items.map(item => item.relation ?? 'and');
+  const [movedItem] = items.splice(sourceIndex, 1);
+  items.splice(targetIndex, 0, movedItem);
+  items.forEach((item, index) => {
+    item.relation = index === items.length - 1
+      ? 'and'
+      : relationsByPosition[index] ?? 'and';
+  });
+  return true;
+}

--- a/src/plugins/filter/filter.style.scss
+++ b/src/plugins/filter/filter.style.scss
@@ -212,6 +212,32 @@ revogr-filter-panel {
       width: 1em;
     }
   }
+
+  .reorder-button {
+    border: 0;
+    background: transparent;
+    color: var(--revo-grid-filter-panel-reorder-color, #6b7280);
+    cursor: grab;
+    font-family: monospace;
+    font-size: 12px;
+    letter-spacing: 0;
+    line-height: 1;
+    padding: 6px 2px;
+    transform: scaleX(0.8);
+    width: 16px;
+
+    &.filter-row-dragging {
+      opacity: 0.55;
+    }
+
+    &.filter-row-drag-over {
+      color: var(--revo-grid-filter-panel-reorder-accent, #007cb2);
+    }
+
+    &:active {
+      cursor: grabbing;
+    }
+  }
 }
 
 .add-filter-divider {

--- a/test/filter.spec.ts
+++ b/test/filter.spec.ts
@@ -5,6 +5,7 @@ import beginsWith from '../src/plugins/filter/conditions/string/beginswith';
 import gtThan from '../src/plugins/filter/conditions/number/greaterThan';
 import lt from '../src/plugins/filter/conditions/number/lessThan';
 import { FilterPlugin } from '../src/plugins/filter/filter.plugin';
+import { getFilterReorderId, moveFilterItem } from '../src/plugins/filter/filter.reorder';
 import { DataStore } from '../src/store/dataSource/data.store';
 import type { ColumnRegular } from '../src';
 import type { FilterData } from '../src/plugins/filter/filter.types';
@@ -52,6 +53,115 @@ describe('notEq', () => {
   it('notEq("Hello", "world") → true, notEq("Hello", "hello") → false (strict inverse of eq)', () => {
     expect(notEq('Hello', 'world')).toBe(true);
     expect(notEq('Hello', 'hello')).toBe(false);
+  });
+});
+
+describe('filter reorder helpers', () => {
+  function createDataTransfer(payloads: Record<string, string>): DataTransfer {
+    return {
+      getData: (type: string) => payloads[type] ?? '',
+    } as DataTransfer;
+  }
+
+  function createFilters(): FilterData[] {
+    return [
+      { id: 1, type: 'contains', value: 'Admin', relation: 'and' },
+      { id: 2, type: 'eq', value: 'Engineer', relation: 'or' },
+      { id: 3, type: 'notEq', value: 'Designer', relation: 'and' },
+    ];
+  }
+
+  describe('getFilterReorderId', () => {
+    it('returns no reorder id for empty drag payloads', () => {
+      expect(getFilterReorderId(createDataTransfer({}))).toBeUndefined();
+      expect(getFilterReorderId(createDataTransfer({ 'text/plain': '   ' }))).toBeUndefined();
+    });
+
+    it('parses a finite reorder id from non-empty drag payloads', () => {
+      expect(getFilterReorderId(createDataTransfer({ 'text/plain': ' 7 ' }))).toBe(7);
+      expect(getFilterReorderId(createDataTransfer({ 'text/revogrid-filter-id': '8', 'text/plain': '7' }))).toBe(8);
+      expect(getFilterReorderId(createDataTransfer({ 'text/plain': 'abc' }))).toBeUndefined();
+    });
+
+    it('keeps finite parsing explicit for special numeric strings', () => {
+      expect(getFilterReorderId(createDataTransfer({ 'text/plain': 'NaN' }))).toBeUndefined();
+      expect(getFilterReorderId(createDataTransfer({ 'text/plain': 'Infinity' }))).toBeUndefined();
+      expect(getFilterReorderId(createDataTransfer({ 'text/plain': '-Infinity' }))).toBeUndefined();
+      expect(getFilterReorderId(createDataTransfer({ 'text/plain': '-3' }))).toBe(-3);
+      expect(getFilterReorderId(createDataTransfer({ 'text/plain': '0' }))).toBe(0);
+      expect(getFilterReorderId(createDataTransfer({ 'text/plain': ' 0 ' }))).toBe(0);
+    });
+  });
+
+  describe('moveFilterItem', () => {
+    it('moves a filter item before an earlier target and preserves condition data', () => {
+      const filters = createFilters();
+
+      expect(moveFilterItem(filters, 3, 1)).toBe(true);
+
+      expect(filters.map(filter => filter.id)).toEqual([3, 1, 2]);
+      expect(filters[0]).toMatchObject({
+        id: 3,
+        type: 'notEq',
+        value: 'Designer',
+      });
+    });
+
+    it('moves a filter item after a later target when dragging downward', () => {
+      const filters = createFilters();
+
+      expect(moveFilterItem(filters, 1, 3)).toBe(true);
+
+      expect(filters.map(filter => filter.id)).toEqual([2, 3, 1]);
+    });
+
+    it('keeps relation connectors assigned by row position after reorder', () => {
+      const filters: FilterData[] = [
+        { id: 1, type: 'contains', value: 'Admin', relation: 'or' },
+        { id: 2, type: 'contains', value: 'Engineer', relation: 'and' },
+      ];
+
+      expect(moveFilterItem(filters, 1, 2)).toBe(true);
+
+      expect(filters).toEqual([
+        { id: 2, type: 'contains', value: 'Engineer', relation: 'or' },
+        { id: 1, type: 'contains', value: 'Admin', relation: 'and' },
+      ]);
+    });
+
+    it('defaults missing relation connectors to and after reorder', () => {
+      const filters: FilterData[] = [
+        { id: 1, type: 'contains', value: 'Admin' },
+        { id: 2, type: 'contains', value: 'Engineer', relation: 'or' },
+        { id: 3, type: 'contains', value: 'Designer', relation: undefined },
+      ];
+
+      expect(moveFilterItem(filters, 3, 1)).toBe(true);
+
+      expect(filters.map(filter => filter.relation)).toEqual(['and', 'or', 'and']);
+    });
+
+    it('normalizes the last hidden relation after reorder', () => {
+      const filters: FilterData[] = [
+        { id: 1, type: 'contains', value: 'Admin', relation: 'and' },
+        { id: 2, type: 'contains', value: 'Engineer', relation: 'or' },
+        { id: 3, type: 'contains', value: 'Designer', relation: 'or' },
+      ];
+
+      expect(moveFilterItem(filters, 3, 1)).toBe(true);
+
+      expect(filters.map(filter => filter.relation)).toEqual(['and', 'or', 'and']);
+    });
+
+    it('keeps filter order unchanged when source or target is invalid', () => {
+      const filters = createFilters();
+
+      expect(moveFilterItem(filters, 1, 1)).toBe(false);
+      expect(moveFilterItem(filters, 99, 1)).toBe(false);
+      expect(moveFilterItem(filters, 1, 99)).toBe(false);
+
+      expect(filters.map(filter => filter.id)).toEqual([1, 2, 3]);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #887

Adds lightweight condition reordering to the core filter panel:

- renders a compact `::` drag handle only when there are 2+ visible filter conditions
- lets users drag a condition row to reorder the existing filter item
- keeps the filter type select, value editor, relation action, and delete action on one row
- extracts reorder helpers into `filter.reorder.ts`

## Validation

- `pnpm -C revogrid exec stencil test test/filter.spec.ts --spec`
- `pnpm -C revogrid exec stencil build --dev`
- `pnpm -C revogrid exec tsc --noEmit --pretty false`

## Notes

The local Playwright e2e runner could not be executed because the Stencil watch web server exits before tests start with `ERR_SOCKET_BAD_PORT` / webServer startup failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filter conditions can be reordered via drag-and-drop when multiple visible filters exist; order updates immediately and preserves condition values and logical connectors.
  * A visible drag handle appears on applicable filter rows and shows hover/active drag states for feedback.

* **Tests**
  * Added end-to-end tests simulating drag interactions and handle visibility rules.
  * Added unit tests for reorder helpers and relation updates.

* **Style**
  * Added styles for the reorder handle and drag states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->