### PR TITLE
Fix row reorder proxy drop target

### DIFF
--- a/e2e/reordering.spec.ts
+++ b/e2e/reordering.spec.ts
@@ -2,6 +2,7 @@ import { expect } from '@playwright/test';
 import { test } from '@stencil/playwright';
 import {
   buildColumns,
+  getVisibleSource,
   mainDataRows,
   mountGrid,
   visibleHeaderTexts,
@@ -48,6 +49,216 @@ test.describe('reordering', () => {
     await expect
       .poll(() => visibleColumnValues(page, 0))
       .not.toEqual(['Alice', 'Ben', 'Cara']);
+  });
+
+  test('keeps row in place when dropping on its original upper boundary', async ({
+    page,
+  }) => {
+    const source = Array.from({ length: 20 }, (_, index) => ({
+      a: `${index}:0`,
+      b: `${index}:1`,
+    }));
+
+    const columns = buildColumns([
+      { prop: 'a', name: 'A', rowDrag: true },
+      { prop: 'b', name: 'B' },
+    ]);
+
+    await mountGrid(page, { columns, source });
+    await page.evaluate(() => {
+      const grid = document.querySelector('revo-grid');
+      if (!grid) {
+        throw new Error('Grid element was not found');
+      }
+      grid.addEventListener('roworderchanged', ((event: CustomEvent) => {
+        (window as any).__rowOrderChanged = event.detail;
+      }) as EventListener);
+    });
+
+    const dragHandle = mainDataRows(page)
+      .nth(5)
+      .locator('[data-rgCol="0"] .revo-draggable');
+    const targetRow = mainDataRows(page).nth(4);
+    const handleBox = await dragHandle.boundingBox();
+    const targetBox = await targetRow.boundingBox();
+
+    expect(handleBox).not.toBeNull();
+    expect(targetBox).not.toBeNull();
+
+    await page.mouse.move(
+      handleBox!.x + handleBox!.width / 2,
+      handleBox!.y + handleBox!.height / 2,
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      targetBox!.x + targetBox!.width / 2,
+      targetBox!.y + targetBox!.height / 2,
+      { steps: 12 },
+    );
+    await page.mouse.up();
+
+    await expect
+      .poll(async () => {
+        const rows = await getVisibleSource<{ a: string }>(page);
+        return rows.map(row => row.a);
+      })
+      .toEqual([
+        '0:0',
+        '1:0',
+        '2:0',
+        '3:0',
+        '4:0',
+        '5:0',
+        '6:0',
+        '7:0',
+        '8:0',
+        '9:0',
+        '10:0',
+        '11:0',
+        '12:0',
+        '13:0',
+        '14:0',
+        '15:0',
+        '16:0',
+        '17:0',
+        '18:0',
+        '19:0',
+      ]);
+    await expect
+      .poll(() => page.evaluate(() => (window as any).__rowOrderChanged))
+      .toBeUndefined();
+  });
+
+  test('inserts an upward-dragged row after the ghost line', async ({
+    page,
+  }) => {
+    const source = Array.from({ length: 20 }, (_, index) => ({
+      a: `${index}:0`,
+      b: `${index}:1`,
+    }));
+
+    const columns = buildColumns([
+      { prop: 'a', name: 'A', rowDrag: true },
+      { prop: 'b', name: 'B' },
+    ]);
+
+    await mountGrid(page, { columns, source });
+
+    const dragHandle = mainDataRows(page)
+      .nth(5)
+      .locator('[data-rgCol="0"] .revo-draggable');
+    const targetRow = mainDataRows(page).nth(3);
+    const handleBox = await dragHandle.boundingBox();
+    const targetBox = await targetRow.boundingBox();
+
+    expect(handleBox).not.toBeNull();
+    expect(targetBox).not.toBeNull();
+
+    await page.mouse.move(
+      handleBox!.x + handleBox!.width / 2,
+      handleBox!.y + handleBox!.height / 2,
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      targetBox!.x + targetBox!.width / 2,
+      targetBox!.y + targetBox!.height / 2,
+      { steps: 12 },
+    );
+    await page.mouse.up();
+
+    await expect
+      .poll(async () => {
+        const rows = await getVisibleSource<{ a: string }>(page);
+        return rows.map(row => row.a);
+      })
+      .toEqual([
+        '0:0',
+        '1:0',
+        '2:0',
+        '3:0',
+        '5:0',
+        '4:0',
+        '6:0',
+        '7:0',
+        '8:0',
+        '9:0',
+        '10:0',
+        '11:0',
+        '12:0',
+        '13:0',
+        '14:0',
+        '15:0',
+        '16:0',
+        '17:0',
+        '18:0',
+        '19:0',
+      ]);
+  });
+
+  test('moves a row down by one position after the ghost line', async ({
+    page,
+  }) => {
+    const source = Array.from({ length: 20 }, (_, index) => ({
+      a: `${index}:0`,
+      b: `${index}:1`,
+    }));
+
+    const columns = buildColumns([
+      { prop: 'a', name: 'A', rowDrag: true },
+      { prop: 'b', name: 'B' },
+    ]);
+
+    await mountGrid(page, { columns, source });
+
+    const dragHandle = mainDataRows(page)
+      .nth(4)
+      .locator('[data-rgCol="0"] .revo-draggable');
+    const targetRow = mainDataRows(page).nth(5);
+    const handleBox = await dragHandle.boundingBox();
+    const targetBox = await targetRow.boundingBox();
+
+    expect(handleBox).not.toBeNull();
+    expect(targetBox).not.toBeNull();
+
+    await page.mouse.move(
+      handleBox!.x + handleBox!.width / 2,
+      handleBox!.y + handleBox!.height / 2,
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      targetBox!.x + targetBox!.width / 2,
+      targetBox!.y + targetBox!.height / 2,
+      { steps: 12 },
+    );
+    await page.mouse.up();
+
+    await expect
+      .poll(async () => {
+        const rows = await getVisibleSource<{ a: string }>(page);
+        return rows.map(row => row.a);
+      })
+      .toEqual([
+        '0:0',
+        '1:0',
+        '2:0',
+        '3:0',
+        '5:0',
+        '4:0',
+        '6:0',
+        '7:0',
+        '8:0',
+        '9:0',
+        '10:0',
+        '11:0',
+        '12:0',
+        '13:0',
+        '14:0',
+        '15:0',
+        '16:0',
+        '17:0',
+        '18:0',
+        '19:0',
+      ]);
   });
 
   test('reorders columns by dragging the header', async ({ page }) => {

--- a/src/components/order/order-row.service.ts
+++ b/src/components/order/order-row.service.ts
@@ -19,16 +19,17 @@ export default class RowOrderService {
     }
     const newRow = this.getCell(e, data);
 
+    // rgRow dragged out table
+    if (newRow.y < 0) {
+      newRow.y = 0;
+    }
+    // rgRow dragged to the top
+    else if (newRow.y < this.currentCell.y) {
+      newRow.y++;
+    }
+
     // if position changed
     if (newRow.y !== this.currentCell.y) {
-      // rgRow dragged out table
-      if (newRow.y < 0) {
-        newRow.y = 0;
-      }
-      // rgRow dragged to the top
-      else if (newRow.y < this.currentCell.y) {
-        newRow.y++;
-      }
       this.config.positionChanged(this.currentCell.y, newRow.y);
     }
     this.clear();

--- a/src/services/data.provider.ts
+++ b/src/services/data.provider.ts
@@ -94,9 +94,13 @@ export class DataProvider {
       newItemsOrder.indexOf(prevItems[from]), // get index in proxy
       1
     );
+    const targetItem = prevItems[from < to ? to + 1 : to];
+    const targetIndex = targetItem === undefined
+      ? newItemsOrder.length
+      : newItemsOrder.indexOf(targetItem);
     // insert before
     newItemsOrder.splice(
-      newItemsOrder.indexOf(prevItems[to]),  // get index in proxy
+      targetIndex,
       0,
       ...toMove
     );


### PR DESCRIPTION
Closes #895

## Summary

Fixes row drag reorder when the drop target resolves to the dragged row's original upper boundary after proxy row ordering is applied.

The regression was introduced when row reorder moved from direct `items.splice(...)` updates to `proxyItems` anchor lookups. After removing the dragged row from `proxyItems`, looking up the dragged row as the target anchor returned `-1`, which made `splice(-1, 0, ...)` insert the row near the bottom.

## Changes

- Resolve the dragged row's proxy index before removal.
- Treat a target anchor equal to the moved row as the original insertion slot.
- Treat an undefined target as append.
- Keep normal target rows inserted before their proxy anchor.
- Add E2E coverage for the no-jump boundary case and upward ghost-line insertion behavior.

## Validation

- `stencil build --dev --serve --no-open`
- `e2e/reordering.spec.ts` passed: 6 tests
- `e2e/row-grouping.spec.ts --grep "allows row reordering inside a group and blocks dragging across groups"` passed
- `e2e/virtualization.spec.ts --grep "keeps deep-scroll row interactions aligned after scroll-space compression"` passed

Note: local Playwright runs used a temporary no-webServer config against the existing `localhost:3333` server because Stencil webServer startup on Node `v24.13.0` hit `ERR_SOCKET_BAD_PORT`. The temporary config was not committed.