### PR TITLE
Fix initial RTL column ordering (#902)

### DIFF
--- a/e2e/layout.spec.ts
+++ b/e2e/layout.spec.ts
@@ -12,6 +12,32 @@ import {
 } from './helpers';
 
 test.describe('layout', () => {
+  test('reverses columns when rtl is enabled before initial connection', async ({
+    page,
+  }) => {
+    await page.setContent(
+      '<div id="grid-host" style="width:900px;height:360px"></div>',
+    );
+    await page.evaluate(() => {
+      const grid = document.createElement('revo-grid');
+      grid.rtl = true;
+      grid.columns = [
+        { prop: 'a', name: 'A (first)' },
+        { prop: 'b', name: 'B' },
+        { prop: 'c', name: 'C (last)' },
+      ];
+      grid.source = [{ a: 1, b: 2, c: 3 }];
+      grid.style.cssText = 'display:block;width:100%;height:100%';
+      document.querySelector('#grid-host')!.append(grid);
+    });
+    await page.waitForChanges();
+
+    const headers = page.locator(SELECTORS.actualHeaderCells);
+    await expect(headers).toHaveCount(3);
+    await expect(headers).toHaveText(['C (last)', 'B', 'A (first)']);
+    await expect(page.locator(SELECTORS.grid)).toHaveAttribute('dir', 'rtl');
+  });
+
   test('does not render inactive header sort or resize affordances', async ({ page }) => {
     const columns = [
       { prop: 'id', name: 'ID', ...withHeaderTestId('inactive-header-id') },

--- a/src/plugins/base.plugin.ts
+++ b/src/plugins/base.plugin.ts
@@ -61,7 +61,7 @@ export class BasePlugin implements PluginBaseComponent {
       },
     });
     if (immediate) {
-      callback(nativeValueDesc?.value);
+      callback(nativeValueDesc?.get ? nativeValueDesc.get.call(this.revogrid) : nativeValueDesc?.value);
     }
   }
 

--- a/test/base-plugin.spec.ts
+++ b/test/base-plugin.spec.ts
@@ -1,0 +1,25 @@
+import { BasePlugin } from '../src/plugins/base.plugin';
+
+describe('BasePlugin', () => {
+  it('provides the current accessor value to immediate watchers', () => {
+    let value = true;
+    const revogrid = {
+      get rtl() {
+        return value;
+      },
+      set rtl(next: boolean) {
+        value = next;
+      },
+    } as HTMLRevoGridElement;
+    const values: boolean[] = [];
+    const plugin = new BasePlugin(revogrid, {} as never);
+
+    plugin.watch<boolean>('rtl', next => values.push(next), {
+      immediate: true,
+    });
+    revogrid.rtl = false;
+
+    expect(values).toEqual([true, false]);
+    expect(revogrid.rtl).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- initialize immediate plugin watchers from accessor-backed grid properties
- preserve the existing runtime RTL column transformation path
- add unit and browser regressions for RTL-first grid initialization

## Root cause

`BasePlugin.watch(..., { immediate: true })` read `PropertyDescriptor.value`. Stencil grid properties such as `rtl` are accessor-backed, so the RTL plugin received `undefined` before the initial column collection was applied and skipped column reversal.

## Impact

Grids configured with `rtl = true` before being connected now render their initial columns in the expected right-to-left logical order without requiring a property toggle or column reassignment.

## Validation

- `pnpm exec stencil build --dev`
- focused watcher unit regression passed during the Stencil spec run
- targeted Playwright test discovery passed
- browser execution was blocked before assertions by the documented Node 24 / Stencil `ERR_SOCKET_BAD_PORT` dev-server startup failure

Fixes #902


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed right-to-left grid layouts so columns render in the correct reversed order when RTL is enabled before the grid loads.
  * Improved immediate property updates so current values are correctly reported for accessor-based settings.

* **Tests**
  * Added coverage for RTL column ordering and immediate watcher updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->