### PR TITLE
fix: use one-based ARIA grid indices

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -1,0 +1,21 @@
+import { expect } from '@playwright/test';
+import { test } from '@stencil/playwright';
+import { buildColumns, dataCell, mountGrid } from './helpers';
+
+test.describe('accessibility', () => {
+  test('uses one-based ARIA indices for data cells', async ({ page }) => {
+    await mountGrid(page, {
+      columns: buildColumns([
+        { prop: 'id', name: 'ID' },
+        { prop: 'name', name: 'Name' },
+      ]),
+      source: [{ id: 101, name: 'Alice' }],
+    });
+
+    const firstCell = dataCell(page, 0, 0);
+
+    await expect(firstCell).toHaveAttribute('role', 'gridcell');
+    await expect(firstCell).toHaveAttribute('aria-colindex', '1');
+    await expect(firstCell).toHaveAttribute('aria-rowindex', '1');
+  });
+});

--- a/src/plugins/wcag/index.ts
+++ b/src/plugins/wcag/index.ts
@@ -2,6 +2,8 @@ import { CellProps, PluginProviders } from '@type';
 import { BasePlugin } from '../base.plugin';
 import { ColumnCollection } from 'src/utils';
 
+const toAriaIndex = (index: number) => `${index + 1}`;
+
 /**
  * WCAG Plugin is responsible for enhancing the accessibility features of the RevoGrid component.
  * It ensures that the grid is fully compliant with Web Content Accessibility Guidelines (WCAG) 2.1.
@@ -53,7 +55,7 @@ export class WCAGPlugin extends BasePlugin {
             const result = columnProperties?.(...args) || {};
 
             result.role = 'columnheader';
-            result['aria-colindex'] = `${index}`;
+            result['aria-colindex'] = toAriaIndex(index);
 
             return result;
           };
@@ -61,8 +63,8 @@ export class WCAGPlugin extends BasePlugin {
           column.cellProperties = (...args) => {
             const wcagProps: CellProps = {
               ['role']: 'gridcell',
-              ['aria-colindex']: `${index}`,
-              ['aria-rowindex']: `${args[0].rowIndex}`,
+              ['aria-colindex']: toAriaIndex(index),
+              ['aria-rowindex']: toAriaIndex(args[0].rowIndex),
               ['tabindex']: -1,
             };
             const columnProps: CellProps = cellProperties?.(...args) || {};
@@ -95,7 +97,7 @@ export class WCAGPlugin extends BasePlugin {
         detail.node.$attrs$ = {
           ...detail.node.$attrs$,
           role: 'row',
-          ['aria-rowindex']: detail.item.itemIndex,
+          ['aria-rowindex']: toAriaIndex(detail.item.itemIndex),
         };
       },
     );

--- a/test/wcag.spec.ts
+++ b/test/wcag.spec.ts
@@ -1,0 +1,57 @@
+import { WCAGPlugin } from '../src/plugins/wcag';
+
+describe('WCAGPlugin', () => {
+  it('uses one-based ARIA indices for headers, rows, and data cells', () => {
+    const revogrid = document.createElement('div') as HTMLRevoGridElement;
+    const firstColumn: Record<string, any> = {};
+    const secondColumn: Record<string, any> = {};
+    new WCAGPlugin(revogrid, {} as never);
+
+    revogrid.dispatchEvent(
+      new CustomEvent('beforecolumnsset', {
+        detail: {
+          columns: {
+            colPinStart: [],
+            rgCol: [firstColumn, secondColumn],
+            colPinEnd: [],
+          },
+        },
+      }),
+    );
+
+    expect(firstColumn.columnProperties()).toMatchObject({
+      'role': 'columnheader',
+      'aria-colindex': '1',
+    });
+    expect(secondColumn.columnProperties()).toMatchObject({
+      'aria-colindex': '2',
+    });
+
+    const firstCellProperties = firstColumn.cellProperties({ rowIndex: 0 });
+
+    expect(firstCellProperties).toMatchObject({
+      'role': 'gridcell',
+      'aria-colindex': '1',
+      'aria-rowindex': '1',
+    });
+    expect(secondColumn.cellProperties({ rowIndex: 4 })).toMatchObject({
+      'aria-colindex': '2',
+      'aria-rowindex': '5',
+    });
+
+    const node = { $attrs$: {} };
+    revogrid.dispatchEvent(
+      new CustomEvent('beforerowrender', {
+        detail: {
+          node,
+          item: { itemIndex: 4 },
+        },
+      }),
+    );
+
+    expect(node.$attrs$).toMatchObject({
+      'role': 'row',
+      'aria-rowindex': '5',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- convert RevoGrid's zero-based internal row and column positions to one-based ARIA indices
- apply the conversion consistently to column headers, rendered rows, and data cells
- add focused unit and Playwright regression coverage

Fixes #940

## Verification

- focused WCAG unit test passes
- focused Playwright accessibility test passes
- Stencil development build passes
- formatting and diff checks pass

## Notes

The broader Stencil test wrapper also discovers `pdf/test/pdf-format.spec.ts`, which currently fails because a Vitest test is loaded through the CommonJS Jest runner. The new WCAG test and all 983 applicable Jest assertions pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved WCAG support with correct one-based ARIA row and column indices.
  * Ensured grid headers, cells, and rows expose appropriate roles and accessibility attributes.

* **Tests**
  * Added automated accessibility coverage for grid roles and ARIA indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->