### PR TITLE
fix(grouping): restore source order after clearing sort

### DIFF
--- a/e2e/row-grouping.spec.ts
+++ b/e2e/row-grouping.spec.ts
@@ -527,7 +527,7 @@ test.describe('row grouping', () => {
     await expect(mainDataRows(page)).toHaveCount(2);
   });
 
-  test('sorts data rows and reapplies grouping', async ({ page }) => {
+  test('restores source order after sorting with and without grouping', async ({ page }) => {
     const source = [
       { id: 1, name: 'Charlie', role: 'Engineer', city: 'Lisbon', team: 'North' },
       { id: 2, name: 'Alice', role: 'Designer', city: 'Porto', team: 'North' },
@@ -546,6 +546,23 @@ test.describe('row grouping', () => {
       { prop: 'role', name: 'Role' },
       { prop: 'city', name: 'City' },
     ]);
+
+    await mountGrid(page, {
+      columns,
+      source,
+      rowHeaders: true,
+    });
+
+    await expectVisibleColumnValues(page, 1, ['Charlie', 'Alice', 'Dan', 'Ben']);
+
+    await page.getByTestId('group-sort-name').click();
+    await expectVisibleColumnValues(page, 1, ['Alice', 'Ben', 'Charlie', 'Dan']);
+
+    await page.getByTestId('group-sort-name').click();
+    await expectVisibleColumnValues(page, 1, ['Dan', 'Charlie', 'Ben', 'Alice']);
+
+    await page.getByTestId('group-sort-name').click();
+    await expectVisibleColumnValues(page, 1, ['Charlie', 'Alice', 'Dan', 'Ben']);
 
     await mountGrid(page, {
       columns,
@@ -571,6 +588,13 @@ test.describe('row grouping', () => {
     await expect(page.locator(`${SELECTORS.mainViewport} .groupingRow`)).toContainText([
       'South',
       'North',
+    ]);
+
+    await page.getByTestId('group-sort-name').click();
+    await expectVisibleColumnValues(page, 1, ['Charlie', 'Alice', 'Dan', 'Ben']);
+    await expect(page.locator(`${SELECTORS.mainViewport} .groupingRow`)).toContainText([
+      'North',
+      'South',
     ]);
   });
 

--- a/src/plugins/groupingRow/grouping.row.plugin.ts
+++ b/src/plugins/groupingRow/grouping.row.plugin.ts
@@ -21,6 +21,7 @@ import { SortingPlugin } from '../sorting/sorting.plugin';
 
 import {
   GROUP_EXPAND_EVENT,
+  GROUP_ORIGINAL_INDEX,
   GROUPING_ROW_TYPE,
   PSEUDO_GROUP_COLUMN,
 } from './grouping.const';
@@ -52,6 +53,8 @@ export * from './grouping.row.renderer';
 
 export class GroupingRowPlugin extends BasePlugin {
   private options: GroupingOptions | undefined;
+  private sortingBaselineActive = false;
+  private isRegrouping = false;
 
   getStore(
     type: DimensionRows = GROUPING_ROW_TYPE,
@@ -177,21 +180,52 @@ export class GroupingRowPlugin extends BasePlugin {
     return options;
   }
 
+  /** Marks the current physical data-row order as the baseline for one sorting cycle. */
+  private captureSortingBaseline() {
+    let originalIndex = 0;
+    this.getStore().get('source').forEach(item => {
+      if (!isGrouping(item)) {
+        item[GROUP_ORIGINAL_INDEX] = originalIndex++;
+      }
+    });
+    this.sortingBaselineActive = true;
+  }
+
   /**
    * Starts global source update with group clearing and applying new one
    * Initiated when need to reapply grouping
    */
-  private doSourceUpdate(options?: ExpandedOptions) {
+  private doSourceUpdate(
+    options?: ExpandedOptions,
+    sortingOrder?: 'preserve' | 'restore',
+  ) {
     /**
      * Get source without grouping
      * @param newOldIndexMap - provides us mapping with new indexes vs old indexes, we would use it for trimmed mapping
      */
     const store = this.getStore();
-    const { source, prevExpanded, oldNewIndexes } = getSource(
+    let { source, prevExpanded, oldNewIndexes } = getSource(
       store.get('source'),
       store.get('proxyItems'),
       true,
     );
+    if (sortingOrder === 'restore') {
+      source = [...source].sort((a, b) =>
+        (a[GROUP_ORIGINAL_INDEX] as number) - (b[GROUP_ORIGINAL_INDEX] as number),
+      );
+      const restoredIndexes = new Map(
+        source.map((item, index) => [item[GROUP_ORIGINAL_INDEX], index]),
+      );
+      oldNewIndexes = {};
+      store.get('source').forEach((item, physicalIndex) => {
+        if (!isGrouping(item)) {
+          const restoredIndex = restoredIndexes.get(item[GROUP_ORIGINAL_INDEX]);
+          if (typeof restoredIndex === 'number') {
+            oldNewIndexes[physicalIndex] = restoredIndex;
+          }
+        }
+      });
+    }
     const expanded: ExpandedOptions = {
       prevExpanded,
       ...options,
@@ -205,19 +239,29 @@ export class GroupingRowPlugin extends BasePlugin {
       depth,
       trimmed,
       oldNewIndexMap,
-    } = gatherGrouping(source, this.options?.props ?? [], expanded);
+    } = gatherGrouping(
+      source,
+      this.options?.props ?? [],
+      expanded,
+      sortingOrder === 'preserve',
+    );
 
     const customRenderer = options?.groupLabelTemplate;
     const cellRenderer = options?.groupCellTemplate;
 
     // setup source
-    this.providers.data.setData(
-      sourceWithGroups,
-      GROUPING_ROW_TYPE,
-      this.revogrid.disableVirtualY,
-      { depth, customRenderer, cellRenderer },
-      true,
-    );
+    this.isRegrouping = true;
+    try {
+      this.providers.data.setData(
+        sourceWithGroups,
+        GROUPING_ROW_TYPE,
+        this.revogrid.disableVirtualY,
+        { depth, customRenderer, cellRenderer },
+        true,
+      );
+    } finally {
+      this.isRegrouping = false;
+    }
     this.updateTrimmed(
       trimmed,
       oldNewIndexes ?? {},
@@ -304,8 +348,12 @@ export class GroupingRowPlugin extends BasePlugin {
       }
       // if sorting is running don't apply grouping, wait for sorting, then it'll apply in @aftersortingapply
       if (this.isSortingRunning()) {
+        if (!this.isRegrouping) {
+          this.sortingBaselineActive = false;
+        }
         return;
       }
+      this.sortingBaselineActive = false;
       this.onDataSet(detail);
     });
     this.addEventListener('beforecolumnsset', ({ detail }) => {
@@ -329,11 +377,22 @@ export class GroupingRowPlugin extends BasePlugin {
      * sorting applied need to clear grouping and apply again
      * based on new results whole grouping order will changed
      */
-    this.addEventListener('aftersortingapply', () => {
+    this.addEventListener('aftersortingapply', ({ detail }) => {
       if (!this.options?.props?.length) {
         return;
       }
-      this.doSourceUpdate(this.getCurrentExpandedOptions());
+      if (detail?.sorting) {
+        if (!this.sortingBaselineActive) {
+          this.captureSortingBaseline();
+        }
+        this.doSourceUpdate(this.getCurrentExpandedOptions(), 'preserve');
+        return;
+      }
+      this.doSourceUpdate(
+        this.getCurrentExpandedOptions(),
+        this.sortingBaselineActive ? 'restore' : undefined,
+      );
+      this.sortingBaselineActive = false;
     });
 
     /**
@@ -354,6 +413,7 @@ export class GroupingRowPlugin extends BasePlugin {
 
   // clear grouping
   clearGrouping() {
+    this.sortingBaselineActive = false;
     // clear columns
     columnTypes.forEach(t => {
       const cols = this.providers.column.getColumns(t);

--- a/src/plugins/groupingRow/grouping.service.ts
+++ b/src/plugins/groupingRow/grouping.service.ts
@@ -11,7 +11,11 @@ import {
 } from './grouping.const';
 import type { ExpandedOptions } from './grouping.row.types';
 
-type GroupedData = Map<string, GroupedData | DataType[]>;
+type GroupedItem = {
+  value: DataType;
+  originalIndex: number;
+};
+type GroupedData = Map<string, GroupedData | GroupedItem[]>;
 type SourceGather = {
   source: DataType[];
   prevExpanded: Record<string, boolean>;
@@ -116,14 +120,14 @@ function flattenGroupMaps({
     }
     if (Array.isArray(innerGroupedValues)) {
       // This branch handles leaf nodes (actual data items)
-      innerGroupedValues.forEach(value => {
+      innerGroupedValues.forEach(({ originalIndex }) => {
         itemIndex += 1;
         if (!isGroupExpanded) {
           trimmed[itemIndex] = true; // Mark items as hidden if group is collapsed
         }
-        oldNewIndexMap[value[GROUP_ORIGINAL_INDEX]] = itemIndex; // Keep track of new positions
+        oldNewIndexMap[originalIndex] = itemIndex; // Keep track of new positions
       });
-      sourceWithGroups.push(...innerGroupedValues);
+      sourceWithGroups.push(...innerGroupedValues.map(({ value }) => value));
     } else {
       // This branch handles nested groups (further subgroups)
       const children = flattenGroupMaps({
@@ -164,6 +168,7 @@ export function gatherGrouping(
     getGroupValue,
     emptyGroupValue = '',
   }: ExpandedOptions,
+  preserveOriginalIndex = false,
 ) {
   const groupedItems: GroupedData = new Map();
   
@@ -186,13 +191,18 @@ export function gatherGrouping(
       currentGroupLevel = currentGroupLevel.get(value) as GroupedData;
     });
     if (!currentGroupLevel.has(lastLevelValue)) {
-      const groupItems: DataType[] = [];
+      const groupItems: GroupedItem[] = [];
       currentGroupLevel.set(lastLevelValue, groupItems);
     }
-    const lastLevelItems = currentGroupLevel.get(lastLevelValue) as DataType[];
+    const lastLevelItems = currentGroupLevel.get(lastLevelValue) as GroupedItem[];
     lastLevelItems.push({
-      ...item,
-      [GROUP_ORIGINAL_INDEX]: originalIndex,
+      originalIndex,
+      value: {
+        ...item,
+        [GROUP_ORIGINAL_INDEX]: preserveOriginalIndex && typeof item[GROUP_ORIGINAL_INDEX] === 'number'
+          ? item[GROUP_ORIGINAL_INDEX]
+          : originalIndex,
+      },
     });
   });
 


### PR DESCRIPTION
## Summary

- preserve the physical data-row order for the duration of a grouped sorting cycle
- restore that baseline when the final active sort is cleared
- keep trim-index remapping independent from the preserved sorting metadata
- extend the row-grouping browser test to compare the complete three-click cycle with and without grouping

## Reproduction

The regression test was added and run before production changes. The ungrouped grid returned to its initial order on the third click, while the grouped grid remained in descending order. The same test passes after this change.

## Validation

- `./node_modules/.bin/stencil build --dev --serve --no-open`
- `./node_modules/.bin/playwright test e2e/row-grouping.spec.ts` — 12 passed
- Core Stencil spec run: 983 tests passed; the aggregate command still exits nonzero because Jest discovers the separate Vitest-based `pdf/test/pdf-format.spec.ts` suite
- `git diff --check`

Fixes #941


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sorting now consistently cycles through ascending, descending, and the original source order.
  - Restoring the original order works correctly both with and without row grouping.
  - Grouped rows now return to their expected source order after completing a sorting cycle.
- **Tests**
  - Expanded coverage verifies sorting behavior across grouped and ungrouped grid views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->