### PR TITLE
fix(row-resize): preserve sizes across grouped remaps

### DIFF
--- a/e2e/row-grouping.spec.ts
+++ b/e2e/row-grouping.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { test } from '@stencil/playwright';
+import { test, type E2EPage } from '@stencil/playwright';
 import {
   SELECTORS,
   buildColumns,
@@ -10,7 +10,350 @@ import {
   withHeaderTestId,
 } from './helpers';
 
+async function enableRowResize(page: E2EPage) {
+  await page.evaluate(() => {
+    const grid = document.querySelector<HTMLRevoGridElement>('revo-grid');
+    if (!grid) throw new Error('Grid was not found');
+    grid.resizeRow = true;
+  });
+  await page.evaluate(async () => {
+    await new Promise<void>(resolve =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+    );
+  });
+  await page.waitForChanges();
+}
+
+function resizeHandle(page: E2EPage, rowIndex: number) {
+  return page.locator(
+    `${SELECTORS.rowHeaderViewport} revogr-data[type="rgRow"][col-type="rowHeaders"] .rgRow[data-rgrow="${rowIndex}"] > .row-resize-handle`,
+  );
+}
+
+async function rowIndexByText(page: E2EPage, text: string) {
+  const index = await mainDataRows(page)
+    .filter({ hasText: text })
+    .first()
+    .getAttribute('data-rgrow');
+  if (index === null) throw new Error(`Row "${text}" was not found`);
+  return Number(index);
+}
+
+async function rowHeightByText(page: E2EPage, text: string) {
+  const box = await mainDataRows(page)
+    .filter({ hasText: text })
+    .first()
+    .boundingBox();
+  if (!box) throw new Error(`Row "${text}" was not rendered`);
+  return box.height;
+}
+
+async function dragResizeHandle(
+  page: E2EPage,
+  rowIndex: number,
+  deltaY: number,
+  release = true,
+) {
+  const box = await resizeHandle(page, rowIndex).boundingBox();
+  expect(box).not.toBeNull();
+  const x = box!.x + box!.width / 2;
+  const y = box!.y + 1;
+  await page.mouse.move(x, y);
+  await page.mouse.down();
+  await page.mouse.move(x, y + deltaY, { steps: 5 });
+  if (release) {
+    await page.mouse.up();
+    await page.waitForChanges();
+  }
+}
+
 test.describe('row grouping', () => {
+  test('keeps a resized data row height when grouping is enabled', async ({
+    page,
+  }) => {
+    await mountGrid(page, {
+      columns: buildColumns([{ prop: 'name', name: 'Name' }]),
+      source: [
+        { name: 'Alice', team: 'North' },
+        { name: 'Ben', team: 'North' },
+        { name: 'Cara', team: 'South' },
+      ],
+      rowHeaders: true,
+      rowSize: 36,
+    });
+    await enableRowResize(page);
+
+    await dragResizeHandle(page, await rowIndexByText(page, 'Alice'), 24);
+    expect(await rowHeightByText(page, 'Alice')).toBeCloseTo(60, 0);
+
+    await page.evaluate(() => {
+      const grid = document.querySelector<HTMLRevoGridElement>('revo-grid');
+      if (!grid) throw new Error('Grid was not found');
+      grid.grouping = { props: ['team'], expandedAll: true };
+    });
+    await page.waitForChanges();
+
+    expect(await rowHeightByText(page, 'Alice')).toBeCloseTo(60, 0);
+    const northGroup = await mainDataRows(page)
+      .filter({ hasText: 'North' })
+      .first()
+      .boundingBox();
+    expect(northGroup?.height).toBeCloseTo(36, 0);
+  });
+
+  test('keeps group-header and child heights attached through regrouping', async ({
+    page,
+  }) => {
+    await mountGrid(page, {
+      columns: buildColumns([{ prop: 'name', name: 'Name' }]),
+      source: [
+        { name: 'Alice', team: 'North' },
+        { name: 'Ben', team: 'North' },
+        { name: 'Cara', team: 'South' },
+      ],
+      grouping: { props: ['team'], expandedAll: true },
+      rowHeaders: true,
+      rowSize: 36,
+    });
+    await enableRowResize(page);
+
+    await dragResizeHandle(page, await rowIndexByText(page, 'North'), 12);
+    await dragResizeHandle(page, await rowIndexByText(page, 'Alice'), 24);
+    await page.evaluate(() => {
+      const grid = document.querySelector<HTMLRevoGridElement>('revo-grid');
+      if (!grid) throw new Error('Grid was not found');
+      grid.grouping = { ...(grid.grouping as object) };
+    });
+    await page.waitForChanges();
+
+    expect(await rowHeightByText(page, 'North')).toBeCloseTo(48, 0);
+    expect(await rowHeightByText(page, 'Alice')).toBeCloseTo(60, 0);
+    expect(await rowHeightByText(page, 'South')).toBeCloseTo(36, 0);
+  });
+
+  test('cancels an active resize before grouping rebuilds indexes', async ({
+    page,
+  }) => {
+    await mountGrid(page, {
+      columns: buildColumns([{ prop: 'name', name: 'Name' }]),
+      source: [
+        { name: 'Alice', team: 'North' },
+        { name: 'Ben', team: 'South' },
+      ],
+      rowHeaders: true,
+      rowSize: 36,
+    });
+    await enableRowResize(page);
+    await page.evaluate(() => {
+      const grid = document.querySelector<HTMLRevoGridElement>('revo-grid');
+      if (!grid) throw new Error('Grid was not found');
+      (globalThis as typeof globalThis & { __groupCancelCount?: number })
+        .__groupCancelCount = 0;
+      grid.addEventListener('rowresizecancel', () => {
+        (globalThis as typeof globalThis & { __groupCancelCount?: number })
+          .__groupCancelCount! += 1;
+      });
+    });
+
+    await dragResizeHandle(page, 0, 24, false);
+    await page.evaluate(() => {
+      const grid = document.querySelector<HTMLRevoGridElement>('revo-grid');
+      if (!grid) throw new Error('Grid was not found');
+      grid.grouping = { props: ['team'], expandedAll: true };
+    });
+    await page.mouse.up();
+    await page.waitForChanges();
+
+    expect(
+      await page.evaluate(
+        () =>
+          (globalThis as typeof globalThis & { __groupCancelCount?: number })
+            .__groupCancelCount,
+      ),
+    ).toBe(1);
+    expect(await rowHeightByText(page, 'North')).toBeCloseTo(36, 0);
+    expect(await rowHeightByText(page, 'Alice')).toBeCloseTo(36, 0);
+  });
+
+  test('remaps resized rows when grouped source is replaced', async ({ page }) => {
+    await mountGrid(page, {
+      columns: buildColumns([{ prop: 'name', name: 'Name' }]),
+      source: [
+        { name: 'Alice', team: 'North' },
+        { name: 'Ben', team: 'North' },
+        { name: 'Cara', team: 'South' },
+      ],
+      grouping: { props: ['team'], expandedAll: true },
+      rowHeaders: true,
+      rowSize: 36,
+    });
+    await enableRowResize(page);
+    await dragResizeHandle(page, await rowIndexByText(page, 'Alice'), 24);
+
+    await page.evaluate(() => {
+      const grid = document.querySelector<HTMLRevoGridElement>('revo-grid');
+      if (!grid) throw new Error('Grid was not found');
+      grid.source = [
+        { name: 'Dora', team: 'South' },
+        { name: 'Evan', team: 'North' },
+        { name: 'Finn', team: 'North' },
+      ];
+    });
+    await page.waitForChanges();
+
+    expect(await rowHeightByText(page, 'Dora')).toBeCloseTo(60, 0);
+    expect(await rowHeightByText(page, 'South')).toBeCloseTo(36, 0);
+    expect(await rowHeightByText(page, 'Evan')).toBeCloseTo(36, 0);
+  });
+
+  test('preserves a resized trailing row when replacement has fewer groups', async ({
+    page,
+  }) => {
+    await mountGrid(page, {
+      columns: buildColumns([{ prop: 'name', name: 'Name' }]),
+      source: [
+        { name: 'A0', team: 'A' },
+        { name: 'A1', team: 'A' },
+        { name: 'B0', team: 'B' },
+        { name: 'B1', team: 'B' },
+        { name: 'C0', team: 'C' },
+        { name: 'C1', team: 'C' },
+      ],
+      grouping: { props: ['team'], expandedAll: true },
+      rowHeaders: true,
+      rowSize: 36,
+    });
+    await enableRowResize(page);
+    await dragResizeHandle(page, await rowIndexByText(page, 'C1'), 24);
+
+    await page.evaluate(() => {
+      const grid = document.querySelector<HTMLRevoGridElement>('revo-grid');
+      if (!grid) throw new Error('Grid was not found');
+      grid.source = Array.from({ length: 6 }, (_, index) => ({
+        name: `New ${index}`,
+        team: 'Only',
+      }));
+    });
+    await page.waitForChanges();
+
+    expect(await rowHeightByText(page, 'New 5')).toBeCloseTo(60, 0);
+    expect(await rowHeightByText(page, 'New 4')).toBeCloseTo(36, 0);
+  });
+
+  test('maps resized rows by physical order when sorted source is replaced', async ({
+    page,
+  }) => {
+    await mountGrid(page, {
+      columns: buildColumns([
+        {
+          prop: 'name',
+          name: 'Name',
+          sortable: true,
+          ...withHeaderTestId('sorted-replacement-resize-name'),
+        },
+      ]),
+      source: [
+        { name: 'Charlie', team: 'Team' },
+        { name: 'Alice', team: 'Team' },
+        { name: 'Dan', team: 'Team' },
+        { name: 'Ben', team: 'Team' },
+      ],
+      grouping: { props: ['team'], expandedAll: true },
+      rowHeaders: true,
+      rowSize: 36,
+    });
+    await enableRowResize(page);
+    await dragResizeHandle(page, await rowIndexByText(page, 'Charlie'), 24);
+    await page.getByTestId('sorted-replacement-resize-name').click();
+    await expectVisibleColumnValues(page, 0, [
+      'Alice',
+      'Ben',
+      'Charlie',
+      'Dan',
+    ]);
+
+    await page.evaluate(() => {
+      const grid = document.querySelector<HTMLRevoGridElement>('revo-grid');
+      if (!grid) throw new Error('Grid was not found');
+      grid.source = [
+        { name: 'Zoe', team: 'Team' },
+        { name: 'Adam', team: 'Team' },
+        { name: 'Mike', team: 'Team' },
+        { name: 'Beth', team: 'Team' },
+      ];
+    });
+    await page.waitForChanges();
+
+    expect(await rowHeightByText(page, 'Zoe')).toBeCloseTo(60, 0);
+    expect(await rowHeightByText(page, 'Mike')).toBeCloseTo(36, 0);
+  });
+
+  test('cancels an active row resize before programmatic sorting', async ({
+    page,
+  }) => {
+    await mountGrid(page, {
+      columns: buildColumns([
+        {
+          prop: 'name',
+          name: 'Name',
+          sortable: true,
+          ...withHeaderTestId('active-resize-sort-name'),
+        },
+      ]),
+      source: [
+        { name: 'Charlie', team: 'North' },
+        { name: 'Alice', team: 'North' },
+        { name: 'Dan', team: 'South' },
+        { name: 'Ben', team: 'South' },
+      ],
+      grouping: { props: ['team'], expandedAll: true },
+      rowHeaders: true,
+      rowSize: 36,
+    });
+    await enableRowResize(page);
+    await page.evaluate(() => {
+      const grid = document.querySelector<HTMLRevoGridElement>('revo-grid');
+      if (!grid) throw new Error('Grid was not found');
+      (
+        globalThis as typeof globalThis & { __resizeCancelCount?: number }
+      ).__resizeCancelCount = 0;
+      grid.addEventListener('rowresizecancel', () => {
+        (
+          globalThis as typeof globalThis & { __resizeCancelCount?: number }
+        ).__resizeCancelCount! += 1;
+      });
+    });
+
+    await dragResizeHandle(
+      page,
+      await rowIndexByText(page, 'Charlie'),
+      24,
+      false,
+    );
+    await page.evaluate(async () => {
+      const grid = document.querySelector<HTMLRevoGridElement>('revo-grid');
+      if (!grid) throw new Error('Grid was not found');
+      await grid.updateColumnSorting({ prop: 'name' }, 'asc', false);
+    });
+    await expect
+      .poll(() => visibleColumnValues(page, 0))
+      .toEqual(['Alice', 'Charlie', 'Ben', 'Dan']);
+    await page.mouse.up();
+    await page.waitForChanges();
+
+    expect(
+      await page.evaluate(
+        () =>
+          (
+            globalThis as typeof globalThis & {
+              __resizeCancelCount?: number;
+            }
+          ).__resizeCancelCount,
+      ),
+    ).toBe(1);
+    expect(await rowHeightByText(page, 'Alice')).toBeCloseTo(36, 0);
+    expect(await rowHeightByText(page, 'Charlie')).toBeCloseTo(36, 0);
+  });
   test('renders grouped rows and toggles expansion', async ({ page }) => {
     const source = [
       { id: 1, name: 'Alice', role: 'Engineer', city: 'Lisbon', team: 'North' },
@@ -531,7 +874,13 @@ test.describe('row grouping', () => {
     page,
   }) => {
     const source = [
-      { id: 1, name: 'Charlie', role: 'Engineer', city: 'Lisbon', team: 'North' },
+      {
+        id: 1,
+        name: 'Charlie',
+        role: 'Engineer',
+        city: 'Lisbon',
+        team: 'North',
+      },
       { id: 2, name: 'Alice', role: 'Designer', city: 'Porto', team: 'North' },
       { id: 3, name: 'Dan', role: 'Analyst', city: 'Coimbra', team: 'South' },
       { id: 4, name: 'Ben', role: 'Manager', city: 'Braga', team: 'South' },
@@ -559,14 +908,23 @@ test.describe('row grouping', () => {
       rowHeaders: true,
     });
 
-    await expectVisibleColumnValues(page, 1, ['Charlie', 'Alice', 'Dan', 'Ben']);
+    await expectVisibleColumnValues(page, 1, [
+      'Charlie',
+      'Alice',
+      'Dan',
+      'Ben',
+    ]);
 
     await page.getByTestId('group-sort-name').click();
-    await expectVisibleColumnValues(page, 1, ['Alice', 'Charlie', 'Ben', 'Dan']);
-    await expect(page.locator(`${SELECTORS.mainViewport} .groupingRow`)).toContainText([
-      'North',
-      'South',
+    await expectVisibleColumnValues(page, 1, [
+      'Alice',
+      'Charlie',
+      'Ben',
+      'Dan',
     ]);
+    await expect(
+      page.locator(`${SELECTORS.mainViewport} .groupingRow`),
+    ).toContainText(['North', 'South']);
 
     await page.evaluate(() => {
       const grid = document.querySelector<HTMLRevoGridElement>('revo-grid');
@@ -576,14 +934,23 @@ test.describe('row grouping', () => {
       };
     });
     await page.waitForChanges();
-    await expectVisibleColumnValues(page, 1, ['Alice', 'Charlie', 'Ben', 'Dan']);
+    await expectVisibleColumnValues(page, 1, [
+      'Alice',
+      'Charlie',
+      'Ben',
+      'Dan',
+    ]);
 
     await page.getByTestId('group-sort-name').click();
-    await expectVisibleColumnValues(page, 1, ['Dan', 'Ben', 'Charlie', 'Alice']);
-    await expect(page.locator(`${SELECTORS.mainViewport} .groupingRow`)).toContainText([
-      'South',
-      'North',
+    await expectVisibleColumnValues(page, 1, [
+      'Dan',
+      'Ben',
+      'Charlie',
+      'Alice',
     ]);
+    await expect(
+      page.locator(`${SELECTORS.mainViewport} .groupingRow`),
+    ).toContainText(['South', 'North']);
     await expect
       .poll(() =>
         page.evaluate(async () => {
@@ -599,11 +966,15 @@ test.describe('row grouping', () => {
       .toEqual(['Charlie', 'Alice', 'Dan', 'Ben']);
 
     await page.getByTestId('group-sort-name').click();
-    await expectVisibleColumnValues(page, 1, ['Charlie', 'Alice', 'Dan', 'Ben']);
-    await expect(page.locator(`${SELECTORS.mainViewport} .groupingRow`)).toContainText([
-      'North',
-      'South',
+    await expectVisibleColumnValues(page, 1, [
+      'Charlie',
+      'Alice',
+      'Dan',
+      'Ben',
     ]);
+    await expect(
+      page.locator(`${SELECTORS.mainViewport} .groupingRow`),
+    ).toContainText(['North', 'South']);
   });
 
   test('restores source order after grouping is cleared during sorting', async ({
@@ -883,7 +1254,13 @@ test.describe('row grouping', () => {
 
   test('does not reopen collapsed groups when sorting', async ({ page }) => {
     const source = [
-      { id: 1, name: 'Charlie', role: 'Engineer', city: 'Lisbon', team: 'North' },
+      {
+        id: 1,
+        name: 'Charlie',
+        role: 'Engineer',
+        city: 'Lisbon',
+        team: 'North',
+      },
       { id: 2, name: 'Alice', role: 'Designer', city: 'Porto', team: 'North' },
       { id: 3, name: 'Dan', role: 'Analyst', city: 'Coimbra', team: 'South' },
       { id: 4, name: 'Ben', role: 'Manager', city: 'Braga', team: 'South' },
@@ -911,7 +1288,9 @@ test.describe('row grouping', () => {
       rowHeaders: true,
     });
 
-    const mainGroupRows = page.locator(`${SELECTORS.mainViewport} .groupingRow`);
+    const mainGroupRows = page.locator(
+      `${SELECTORS.mainViewport} .groupingRow`,
+    );
     await mainGroupRows
       .filter({ hasText: 'North' })
       .locator(SELECTORS.groupExpandButton)
@@ -921,10 +1300,9 @@ test.describe('row grouping', () => {
 
     await page.getByTestId('group-sort-preserve-collapse-name').click();
 
-    await expect(page.locator(`${SELECTORS.mainViewport} .groupingRow`)).toContainText([
-      'North',
-      'South',
-    ]);
+    await expect(
+      page.locator(`${SELECTORS.mainViewport} .groupingRow`),
+    ).toContainText(['North', 'South']);
     await expect(mainGroupRows).toHaveCount(2);
     await expectVisibleColumnValues(page, 1, ['Ben', 'Dan']);
 
@@ -932,7 +1310,12 @@ test.describe('row grouping', () => {
       .filter({ hasText: 'North' })
       .locator(SELECTORS.groupExpandButton)
       .click();
-    await expectVisibleColumnValues(page, 1, ['Alice', 'Charlie', 'Ben', 'Dan']);
+    await expectVisibleColumnValues(page, 1, [
+      'Alice',
+      'Charlie',
+      'Ben',
+      'Dan',
+    ]);
   });
 
   test('allows row reordering inside a group and blocks dragging across groups', async ({ page }) => {

--- a/e2e/row-resize.spec.ts
+++ b/e2e/row-resize.spec.ts
@@ -412,6 +412,40 @@ test.describe('row resize plugin', () => {
     expect(after!.height).toBeCloseTo(before!.height, 0);
   });
 
+  test('does not start a gesture when before-row-resize disables the plugin', async ({
+    page,
+  }) => {
+    await mountGrid(page, {
+      columns: buildColumns([{ prop: 'name', name: 'Name' }]),
+      source: [{ name: 'Alice' }],
+      rowHeaders: true,
+      rowSize: 36,
+    });
+    await enableRowResize(page);
+    await page.evaluate(() => {
+      const grid = document.querySelector<HTMLRevoGridElement>('revo-grid');
+      if (!grid) throw new Error('Grid was not found');
+      grid.addEventListener(
+        'beforerowresize',
+        () => {
+          grid.resizeRow = false;
+        },
+        { once: true },
+      );
+    });
+
+    await dragHandle(page, resizeHandle(page, 0), 24);
+
+    expect((await rowHeightsByText(page, 'Alice')).data).toBeCloseTo(36, 0);
+    await expect(resizeHandle(page, 0)).toHaveCount(0);
+    expect(
+      await page.evaluate(() => {
+        const grid = document.querySelector<HTMLRevoGridElement>('revo-grid');
+        return grid?.rowDefinitions;
+      }),
+    ).toEqual([]);
+  });
+
   test('keeps pinned, grouped, and deep virtual rows aligned', async ({
     page,
   }) => {
@@ -465,6 +499,44 @@ test.describe('row resize plugin', () => {
     const deepHeader = await rowHeaderCell(page, 800).boundingBox();
     const deepCell = await dataCell(page, 800, 0).boundingBox();
     expect(Math.abs(deepHeader!.height - deepCell!.height)).toBeLessThan(2);
+  });
+
+  test('preserves provider-owned main and pinned sizes when a resize commits', async ({
+    page,
+  }) => {
+    await mountGrid(page, {
+      columns: buildColumns([{ prop: 'name', name: 'Name' }]),
+      source: [{ name: 'Alice' }, { name: 'Ben' }],
+      pinnedTopSource: [{ name: 'Pinned' }],
+      rowHeaders: true,
+      rowSize: 36,
+    });
+    await enableRowResize(page);
+    await page.evaluate(async () => {
+      const grid = document.querySelector<HTMLRevoGridElement>('revo-grid');
+      if (!grid) throw new Error('Grid was not found');
+      const providers = await grid.getProviders();
+      providers?.dimension.setCustomSizes('rgRow', { 1: 81 }, true);
+      providers?.dimension.setCustomSizes('rowPinStart', { 0: 54 }, true);
+    });
+    await expect
+      .poll(async () => (await rowHeightsByText(page, 'Ben')).data)
+      .toBeCloseTo(81, 0);
+    const pinnedRow = page
+      .locator(
+        `${SELECTORS.mainViewport} revogr-data[type="rowPinStart"] [data-rgrow="0"]`,
+      )
+      .first();
+    await expect
+      .poll(async () => (await pinnedRow.boundingBox())?.height)
+      .toBeCloseTo(54, 0);
+
+    await dragHandle(page, resizeHandle(page, 0), 24);
+
+    expect((await rowHeightsByText(page, 'Alice')).data).toBeCloseTo(60, 0);
+    expect((await rowHeightsByText(page, 'Ben')).data).toBeCloseTo(81, 0);
+    const pinned = await pinnedRow.boundingBox();
+    expect(pinned?.height).toBeCloseTo(54, 0);
   });
 
   test('preserves plugin and row-definition heights while filtering', async ({
@@ -680,6 +752,86 @@ test.describe('row resize plugin', () => {
     expect(jane.data).toBeCloseTo(72, 0);
     expect(mike.header).toBeCloseTo(mike.data, 0);
     expect(jane.header).toBeCloseTo(jane.data, 0);
+  });
+
+  test('preserves independent row sizes when sort and filter remap colliding indexes', async ({
+    page,
+  }) => {
+    await mountGrid(page, {
+      columns: buildColumns([
+        {
+          prop: 'name',
+          name: 'Name',
+          sortable: true,
+          ...withHeaderTestId('colliding-row-size-sort-name'),
+        },
+        {
+          prop: 'status',
+          name: 'Status',
+          filter: true,
+          ...withHeaderTestId('colliding-row-size-filter-status'),
+        },
+      ]),
+      source: [
+        { name: 'Zulu', status: 'keep' },
+        { name: 'Mike', status: 'keep' },
+        { name: 'Amy', status: 'hide' },
+        { name: 'Yuri', status: 'keep' },
+        { name: 'Bob', status: 'keep' },
+        { name: 'Jane', status: 'keep' },
+        { name: 'Cara', status: 'keep' },
+        { name: 'Xena', status: 'keep' },
+      ],
+      filter: true,
+      rowHeaders: true,
+      rowSize: 36,
+      rowDefinitions: [{ type: 'rgRow', index: 5, size: 72 }],
+    });
+    await enableRowResize(page);
+
+    await dragHandle(page, resizeHandle(page, 0), 24);
+    await page.getByTestId('colliding-row-size-sort-name').click();
+    await expect
+      .poll(() => visibleColumnValues(page, 0))
+      .toEqual(['Amy', 'Bob', 'Cara', 'Jane', 'Mike', 'Xena', 'Yuri', 'Zulu']);
+    expect((await rowHeightsByText(page, 'Jane')).data).toBeCloseTo(72, 0);
+    expect((await rowHeightsByText(page, 'Zulu')).data).toBeCloseTo(60, 0);
+
+    await page.evaluate(async () => {
+      const grid = document.querySelector<HTMLRevoGridElement>('revo-grid');
+      if (!grid) throw new Error('Grid was not found');
+      const providers = await grid.getProviders();
+      // Filtering Amy moves Yuri from virtual index 6 to index 5, deliberately
+      // colliding with Jane's physical row-definition index 5 during remap.
+      providers?.dimension.setCustomSizes('rgRow', { 6: 81 }, true);
+    });
+
+    await page
+      .getByTestId('colliding-row-size-filter-status')
+      .locator(SELECTORS.filterButton)
+      .click();
+    const panel = page.locator(SELECTORS.filterPanel);
+    await panel.getByRole('combobox').selectOption({ label: 'Contains' });
+    await page.locator(SELECTORS.filterInput).fill('keep');
+    await expect
+      .poll(() => visibleColumnValues(page, 0))
+      .toEqual(['Bob', 'Cara', 'Jane', 'Mike', 'Xena', 'Yuri', 'Zulu']);
+
+    const heights = await Promise.all(
+      ['Bob', 'Cara', 'Jane', 'Mike', 'Xena', 'Yuri', 'Zulu'].map(
+        async name =>
+          [name, (await rowHeightsByText(page, name)).data] as const,
+      ),
+    );
+    expect(Object.fromEntries(heights)).toEqual({
+      Bob: 36,
+      Cara: 36,
+      Jane: 72,
+      Mike: 36,
+      Xena: 36,
+      Yuri: 81,
+      Zulu: 60,
+    });
   });
 
   test('keeps a resized grouped row attached to its source across sort and clear', async ({

--- a/src/components/revoGrid/revo-grid.tsx
+++ b/src/components/revoGrid/revo-grid.tsx
@@ -48,6 +48,7 @@ import type {
   AdditionalData,
   PendingColumnFocusRestore,
   ClipboardConfig,
+  ViewSettingSizeProp,
 } from '@type';
 
 import ColumnDataProvider from '../../services/column.data.provider';
@@ -80,7 +81,7 @@ import {
   StretchColumn,
   isStretchPlugin,
 } from '../../plugins/column.stretch.plugin';
-import { rowDefinitionByType, rowDefinitionRemoveByType } from './grid.helpers';
+import { rowDefinitionByType } from './grid.helpers';
 import { ColumnMovePlugin } from '../../plugins/moveColumn/column.drag.plugin';
 import { getPropertyFromEvent } from '../../utils/events';
 import { isMobileDevice } from '../../utils/mobile';
@@ -1486,28 +1487,34 @@ export class RevoGridComponent {
       oldVals: before,
     });
     this.dimensionProvider.syncRowDefinitions(newVal);
-    // apply new values
     const newRows = rowDefinitionByType(newVal);
-    // clear current defs
-    if (oldVal) {
-      const remove = rowDefinitionRemoveByType(oldVal);
-      // clear all old data and drop sizes
-      for (const t in remove) {
-        if (remove.hasOwnProperty(t)) {
-          const type = t as DimensionRows;
-          const store = this.dataProvider.stores[type];
-          const itemCount = store.store.get('items').length;
-          this.dimensionProvider.clearSize(type, itemCount);
-        }
-      }
-    }
-    // set new sizes
+    const oldRows = rowDefinitionByType(oldVal);
+    const dataProvider = this.dataProvider;
+    const dimensionProvider = this.dimensionProvider;
     rowTypes.forEach((t) => {
       const newSizes = newRows[t];
-      // apply new sizes or force update
-      if (newSizes || forceUpdate) {
-        this.dimensionProvider?.setCustomSizes(t, newSizes?.sizes || {});
+      const oldSizes = oldRows[t];
+      if (!newSizes && !oldSizes && !forceUpdate) {
+        return;
       }
+      const sizes: ViewSettingSizeProp = {
+        ...dimensionProvider.stores[t].store.get('sizes'),
+      };
+      const definitionSizes = newSizes?.sizes || {};
+      const previousDefinitionSizes = oldSizes?.sizes || {};
+      const items = dataProvider.stores[t].store.get('items');
+      items.forEach((physicalIndex, virtualIndex) => {
+        if (
+          Object.hasOwn(previousDefinitionSizes, physicalIndex) &&
+          sizes[virtualIndex] === previousDefinitionSizes[physicalIndex]
+        ) {
+          delete sizes[virtualIndex];
+        }
+        if (Object.hasOwn(definitionSizes, physicalIndex)) {
+          sizes[virtualIndex] = definitionSizes[physicalIndex];
+        }
+      });
+      dimensionProvider.setCustomSizes(t, sizes);
     });
   }
 

--- a/src/plugins/groupingRow/grouping.const.ts
+++ b/src/plugins/groupingRow/grouping.const.ts
@@ -11,4 +11,5 @@ export const GROUP_COLUMN_PROP = `${GRID_INTERNALS}-prop`;
 export const GROUP_ORIGINAL_INDEX = `${GRID_INTERNALS}-original-index`;
 export const GROUP_EXPAND_BTN = `group-expand`;
 export const GROUP_EXPAND_EVENT = `groupexpandclick`;
+export const BEFORE_GROUPING_APPLY_EVENT = `beforegroupingapply`;
 export const GROUPING_ROW_TYPE: DimensionRows = 'rgRow';

--- a/src/plugins/groupingRow/grouping.row.plugin.ts
+++ b/src/plugins/groupingRow/grouping.row.plugin.ts
@@ -19,9 +19,11 @@ import { SortingPlugin, hasActiveSorting } from '../sorting/sorting.plugin';
 
 import type { Observable, ColumnCollection } from '../../utils';
 import {
+  BEFORE_GROUPING_APPLY_EVENT,
   GROUP_EXPAND_EVENT,
   GROUPING_ROW_TYPE,
   PSEUDO_GROUP_COLUMN,
+  PSEUDO_GROUP_ITEM_ID,
 } from './grouping.const';
 import { doExpand, doCollapse } from './grouping.row.expand.service';
 import type {
@@ -38,6 +40,7 @@ import {
   isGroupingColumn,
 } from './grouping.service';
 import {
+  convertGroupingIndex,
   filterOutEmptyGroupRows,
   processDoubleConversionTrimmed,
   TRIMMED_GROUPING,
@@ -198,12 +201,19 @@ export class GroupingRowPlugin extends BasePlugin {
     const cellRenderer = options?.groupCellTemplate;
 
     // setup source
+    this.revogrid.dispatchEvent(new CustomEvent(BEFORE_GROUPING_APPLY_EVENT));
     this.providers.data.setData(
       sourceWithGroups,
       GROUPING_ROW_TYPE,
       this.revogrid.disableVirtualY,
       { depth, customRenderer, cellRenderer },
       true,
+    );
+    this.remapRowDefinitions(
+      oldNewIndexes ?? {},
+      oldNewIndexMap,
+      currentSource,
+      sourceWithGroups,
     );
     this.updateTrimmed(
       trimmed,
@@ -222,13 +232,18 @@ export class GroupingRowPlugin extends BasePlugin {
    * If source came from other plugin
    */
   private onDataSet(data: BeforeSourceSetEvent) {
+    const currentSource = this.getStore().get('source');
+    const sortingPlugin = this.providers.plugins.getByClass(SortingPlugin);
+    const currentItems = this.isSortingActiveOrPending(sortingPlugin)
+      ? currentSource.map((_, index) => index)
+      : this.getStore().get('proxyItems');
+    const { prevExpanded, oldNewIndexes } = getSource(
+      currentSource,
+      currentItems,
+      true,
+    );
     let preservedExpanded: ExpandedOptions['prevExpanded'] = {};
     if (this.options?.preserveGroupingOnUpdate !== false) {
-      let { prevExpanded } = getSource(
-        this.getStore().get('source'),
-        this.getStore().get('proxyItems'),
-        true,
-      );
       preservedExpanded = prevExpanded;
     }
     const source = data.source.filter(s => !isGrouping(s));
@@ -248,6 +263,14 @@ export class GroupingRowPlugin extends BasePlugin {
       customRenderer: options.groupLabelTemplate,
       cellRenderer: options.groupCellTemplate,
     });
+    queueMicrotask(() =>
+      this.remapRowDefinitions(
+        oldNewIndexes ?? {},
+        oldNewIndexMap,
+        currentSource,
+        sourceWithGroups,
+      ),
+    );
     this.updateTrimmed(
       trimmed,
       oldNewIndexMap,
@@ -356,6 +379,7 @@ export class GroupingRowPlugin extends BasePlugin {
       sourceItems,
       true,
     );
+    this.revogrid.dispatchEvent(new CustomEvent(BEFORE_GROUPING_APPLY_EVENT));
     this.providers.data.setData(
       source,
       GROUPING_ROW_TYPE,
@@ -363,9 +387,62 @@ export class GroupingRowPlugin extends BasePlugin {
       undefined,
       true,
     );
+    this.remapRowDefinitions(
+      oldNewIndexes ?? {},
+      undefined,
+      currentSource,
+      source,
+    );
     this.updateTrimmed(undefined, undefined, oldNewIndexes, source);
     if (hasActiveSorting(sortingPlugin?.sorting)) {
       sortingPlugin?.reapplySorting();
+    }
+  }
+
+  private remapRowDefinitions(
+    firstLevelMap: Record<number, number>,
+    secondLevelMap?: Record<number, number>,
+    previousSource?: DataType[],
+    nextSource?: DataType[],
+  ) {
+    const definitions = this.providers.dimension.getRowDefinitions();
+    const nextGroupIndexes = new Map<string, number>();
+    nextSource?.forEach((row, index) => {
+      const groupId = row[PSEUDO_GROUP_ITEM_ID];
+      if (groupId && !nextGroupIndexes.has(groupId)) {
+        nextGroupIndexes.set(groupId, index);
+      }
+    });
+    let changed = false;
+    const remapped = definitions.flatMap(definition => {
+      if (definition.type !== GROUPING_ROW_TYPE) {
+        return [definition];
+      }
+      const previousRow = previousSource?.[definition.index];
+      const groupId = previousRow?.[PSEUDO_GROUP_ITEM_ID];
+      const index = groupId
+        ? nextGroupIndexes.get(groupId)
+        : convertGroupingIndex(
+            definition.index,
+            firstLevelMap,
+            secondLevelMap,
+          );
+      if (typeof index !== 'number') {
+        changed = true;
+        return [];
+      }
+      if (index < 0) {
+        changed = true;
+        return [];
+      }
+      if (index === definition.index) {
+        return [definition];
+      }
+      changed = true;
+      return [{ ...definition, index }];
+    });
+    if (changed) {
+      this.providers.dimension.setRowDefinitions(remapped);
     }
   }
 

--- a/src/plugins/groupingRow/grouping.trimmed.service.ts
+++ b/src/plugins/groupingRow/grouping.trimmed.service.ts
@@ -12,12 +12,15 @@ export const TRIMMED_GROUPING = 'grouping';
  * against the grouped physical source can still be remapped. If neither path
  * resolves to a number, the caller drops the stale trim entry.
  */
-function convertTrimmedIndex(
-  initialIndex: string,
+export function convertGroupingIndex(
+  initialIndex: string | number,
   firstLevelMap: Record<number, number>,
   secondLevelMap?: Record<number, number>,
 ) {
-  const sourceIndex = Number.parseInt(initialIndex, 10);
+  const sourceIndex =
+    typeof initialIndex === 'number'
+      ? initialIndex
+      : Number.parseInt(initialIndex, 10);
   const firstConversionIndex = firstLevelMap[sourceIndex];
   if (!secondLevelMap) {
     return firstConversionIndex;
@@ -53,7 +56,7 @@ export function processDoubleConversionTrimmed(initiallyTrimed: Trimmed, firstLe
        * if item exists we find it in collection
        * we support 2 level of conversions
        */
-      const newConversionIndex = convertTrimmedIndex(
+      const newConversionIndex = convertGroupingIndex(
         initialIndex,
         firstLevelMap,
         secondLevelMap,

--- a/src/plugins/row-resize/row-resize.plugin.tsx
+++ b/src/plugins/row-resize/row-resize.plugin.tsx
@@ -14,7 +14,10 @@ import type {
   RowResizeConfig,
   RowResizeEventDetail,
 } from './row-resize.types';
-import { GROUP_EXPAND_EVENT } from '../groupingRow/grouping.const';
+import {
+  BEFORE_GROUPING_APPLY_EVENT,
+  GROUP_EXPAND_EVENT,
+} from '../groupingRow/grouping.const';
 import {
   clampRowResizeHeight,
   createRowResizePatch,
@@ -40,7 +43,6 @@ type ActiveResize = {
   previousSizes: ViewSettingSizeProp;
   originalCustomSizes: ViewSettingSizeProp;
   bottomAnchored: boolean;
-  startEvent: PointerEvent;
   lastEvent: PointerEvent;
 };
 
@@ -49,16 +51,16 @@ export class RowResizePlugin extends BasePlugin {
   private enabled = false;
 
   private active?: ActiveResize;
-  private readonly committedSizes = new Map<
+  private readonly appliedDefinitionIndexes = new Map<
     DimensionRows,
-    Map<number, number>
+    Set<number>
   >();
-  private readonly appliedIndexes = new Map<DimensionRows, Set<number>>();
   private animationFrame?: number;
   private pendingHeight?: number;
   private pendingBottomAnchor = false;
   private keepBottomAnchor = false;
   private rowDefinitionRemapQueued = false;
+  private readonly pendingSourceCounts = new Map<DimensionRows, number>();
   private previousBodyCursor = '';
 
   constructor(
@@ -71,60 +73,38 @@ export class RowResizePlugin extends BasePlugin {
     if (new.target !== RowResizePlugin) {
       this.enabled = true;
       this.registerEventListeners();
-    } else {
-      this.syncGridConfig(false);
     }
   }
 
   private registerEventListeners() {
     this.addEventListener('beforerowrender', this.decorateRow);
-    this.addEventListener('beforeanysource', ({ detail }) => {
+    this.addEventListener('beforeanysource', () => {
       this.cancel('data-change');
       this.keepBottomAnchor = false;
-      const committed = this.committedSizes.get(detail.type);
-      if (!committed) {
-        return;
-      }
-      const removedIndexes = new Set<number>();
-      for (const index of committed.keys()) {
-        if (index >= detail.source.length) {
-          committed.delete(index);
-          removedIndexes.add(index);
-        }
-      }
-      if (removedIndexes.size) {
-        const rowDefinitions = this.providers.dimension
-          .getRowDefinitions()
-          .filter(
-            definition =>
-              definition.type !== detail.type ||
-              !removedIndexes.has(definition.index),
-          );
-        this.providers.dimension.setRowDefinitions(rowDefinitions);
-      }
     });
-    this.addEventListener('afteranysource', this.rebuildCommittedSizes);
-    this.addEventListener('beforesourcesortingapply', this.cancelForDataChange);
-    this.addEventListener('aftersortingapply', this.reapplyCommittedSizes);
-    this.addEventListener('beforefilterapply', this.cancelForDataChange);
-    this.addEventListener('afterfilterapply', this.scheduleRowDefinitionRemap);
-    this.addEventListener('beforerowdefinition', ({ detail }) => {
-      this.cancel('data-change');
-      if (detail.vals !== this.providers.dimension.getRowDefinitions()) {
-        this.committedSizes.clear();
-      }
+    this.addEventListener('afteranysource', ({ detail }) => {
+      this.pendingSourceCounts.set(detail.type, detail.source.length);
       this.scheduleRowDefinitionRemap();
     });
-    this.addEventListener('afterthemechanged', this.reapplyCommittedSizes);
-    this.addEventListener('aftertrimmed', this.scheduleRowDefinitionRemap);
-    this.addEventListener('roworderchange', () => {
-      queueMicrotask(this.reapplyCommittedSizes);
+    this.addEventListener('beforesourcesortingapply', this.cancelForDataChange);
+    this.addEventListener('beforesortingapply', this.cancelForDataChange);
+    this.addEventListener('sortingconfigchanged', this.cancelForDataChange);
+    this.addEventListener(BEFORE_GROUPING_APPLY_EVENT, this.cancelForDataChange);
+    this.addEventListener('aftersortingapply', this.scheduleRowDefinitionRemap);
+    this.addEventListener('beforefilterapply', this.cancelForDataChange);
+    this.addEventListener('afterfilterapply', this.scheduleRowDefinitionRemap);
+    this.addEventListener('beforerowdefinition', () => {
+      this.cancel('data-change');
+      this.scheduleRowDefinitionRemap();
     });
+    this.addEventListener('afterthemechanged', this.scheduleRowDefinitionRemap);
+    this.addEventListener('aftertrimmed', this.scheduleRowDefinitionRemap);
+    this.addEventListener('roworderchange', this.scheduleRowDefinitionRemap);
     this.addEventListener(GROUP_EXPAND_EVENT, () => {
       if (this.keepBottomAnchor) {
         this.pendingBottomAnchor = true;
       }
-      queueMicrotask(this.reapplyCommittedSizes);
+      this.scheduleRowDefinitionRemap();
     });
     this.addEventListener('aftergridrender', this.applyPendingBottomAnchor);
     this.addEventListener('viewportscroll', this.updateBottomAnchorState);
@@ -136,16 +116,21 @@ export class RowResizePlugin extends BasePlugin {
   }
 
   syncGridConfig(refresh = true) {
-    const { resizeRow } = this.revogrid;
-    const hasConfiguredPlugin = this.providers.plugins
-      .get()
-      .some(plugin => plugin !== this && plugin instanceof RowResizePlugin);
-    const enabled =
-      this.constructor !== RowResizePlugin ||
-      (!hasConfiguredPlugin && !!resizeRow);
-    const config = resolveRowResizeConfig(
-      typeof resizeRow === 'object' ? resizeRow : undefined,
+    const { plugins = [], resizeRow } = this.revogrid;
+    const isCorePlugin = this.constructor === RowResizePlugin;
+    const hasConfiguredPlugin = plugins.some(
+      plugin =>
+        plugin !== RowResizePlugin &&
+        plugin.prototype instanceof RowResizePlugin,
     );
+    const enabled =
+      !isCorePlugin ||
+      (!hasConfiguredPlugin && !!resizeRow);
+    const resizeConfig =
+      typeof resizeRow === 'object' ? resizeRow : undefined;
+    const config = isCorePlugin
+      ? resolveRowResizeConfig(resizeConfig)
+      : this.config;
     const configChanged =
       config.minHeight !== this.config.minHeight ||
       config.maxHeight !== this.config.maxHeight ||
@@ -164,6 +149,7 @@ export class RowResizePlugin extends BasePlugin {
         this.pendingBottomAnchor = false;
         this.keepBottomAnchor = false;
         this.rowDefinitionRemapQueued = false;
+        this.pendingSourceCounts.clear();
         this.clearSubscriptions();
       }
     }
@@ -212,7 +198,6 @@ export class RowResizePlugin extends BasePlugin {
     const dimension = this.providers.dimension.stores[rowType];
     const dimensionState = dimension.getCurrentState();
     const viewport = this.providers.viewport.stores[rowType];
-    const viewportState = viewport.store.state;
     const item = getItemByIndex(dimensionState, index);
     const focusedStore = this.providers.selection.focusedStore;
     const selectedRowType = focusedStore
@@ -250,24 +235,27 @@ export class RowResizePlugin extends BasePlugin {
       originalCustomSizes: { ...dimensionState.sizes },
       bottomAnchored:
         rowType === 'rgRow' &&
-        dimensionState.realSize > viewportState.clientSize &&
-        viewport.lastCoordinate >=
-          getViewportMaxCoordinate(dimensionState, viewportState.virtualSize),
-      startEvent: event,
+        this.isMainViewportAtBottom(viewport.lastCoordinate),
       lastEvent: event,
     };
 
+    this.active = active;
     const beforeEvent = this.emit<RowResizeEventDetail>(
       BEFORE_ROW_RESIZE_EVENT,
       this.eventDetail(active, event, startHeight),
     );
     if (beforeEvent.defaultPrevented) {
+      if (this.active === active) {
+        this.active = undefined;
+      }
+      return;
+    }
+    if (!this.enabled || this.active !== active) {
       return;
     }
 
     event.preventDefault();
     event.stopPropagation();
-    this.active = active;
     const doc = this.revogrid.ownerDocument;
     this.previousBodyCursor = doc.body?.style.cursor || '';
     if (doc.body) {
@@ -380,7 +368,7 @@ export class RowResizePlugin extends BasePlugin {
     const detail = {
       ...this.eventDetail(
         active,
-        active.lastEvent || active.startEvent,
+        active.lastEvent,
         active.startHeight,
       ),
       reason,
@@ -409,21 +397,9 @@ export class RowResizePlugin extends BasePlugin {
       return;
     }
     const items = this.providers.data.stores[active.rowType].store.get('items');
-    let committed = this.committedSizes.get(active.rowType);
-    if (!committed) {
-      committed = new Map();
-      this.committedSizes.set(active.rowType, committed);
-    }
-    let applied = this.appliedIndexes.get(active.rowType);
-    if (!applied) {
-      applied = new Set();
-      this.appliedIndexes.set(active.rowType, applied);
-    }
     const physicalIndexes = active.indexes.reduce<number[]>((result, index) => {
       const physicalIndex = items[index];
       if (physicalIndex !== undefined) {
-        committed.set(physicalIndex, active.currentHeight);
-        applied.add(index);
         result.push(physicalIndex);
       }
       return result;
@@ -436,6 +412,7 @@ export class RowResizePlugin extends BasePlugin {
         active.currentHeight,
       );
       this.providers.dimension.setRowDefinitions(rowDefinitions);
+      this.scheduleRowDefinitionRemap();
       this.keepBottomAnchor = active.bottomAnchored;
       this.requestBottomAnchor(active);
     }
@@ -447,20 +424,22 @@ export class RowResizePlugin extends BasePlugin {
     }
   }
 
+  private isMainViewportAtBottom(coordinate: number) {
+    const dimension = this.providers.dimension.stores.rgRow.getCurrentState();
+    const viewport = this.providers.viewport.stores.rgRow.store.state;
+    return (
+      dimension.realSize > viewport.clientSize &&
+      coordinate >= getViewportMaxCoordinate(dimension, viewport.virtualSize)
+    );
+  }
+
   private readonly updateBottomAnchorState = ({
     detail,
   }: CustomEvent<ViewPortScrollEvent>) => {
     if (detail.dimension !== 'rgRow') {
       return;
     }
-    const dimension = this.providers.dimension.stores.rgRow.store;
-    const viewport = this.providers.viewport.stores.rgRow.store;
-    const realSize = dimension.get('realSize');
-    const clientSize = viewport.get('clientSize');
-    this.keepBottomAnchor =
-      realSize > clientSize &&
-      detail.coordinate >=
-        realSize - clientSize - dimension.get('originItemSize');
+    this.keepBottomAnchor = this.isMainViewportAtBottom(detail.coordinate);
   };
 
   private readonly applyPendingBottomAnchor = () => {
@@ -475,37 +454,6 @@ export class RowResizePlugin extends BasePlugin {
     void this.revogrid.scrollToCoordinate({ y: dimension.get('realSize') });
   };
 
-  private readonly reapplyCommittedSizes = () =>
-    this.applyCommittedSizes(false);
-
-  private readonly rebuildCommittedSizes = () => {
-    this.applyCommittedSizes(true);
-    this.scheduleRowDefinitionRemap();
-  };
-
-  private applyCommittedSizes(clearAppliedIndexes: boolean) {
-    for (const [rowType, committed] of this.committedSizes) {
-      const dimension = this.providers.dimension.stores[rowType];
-      const sizes = { ...dimension.store.get('sizes') };
-      if (clearAppliedIndexes) {
-        for (const index of this.appliedIndexes.get(rowType) || []) {
-          delete sizes[index];
-        }
-      }
-      const items = this.providers.data.stores[rowType].store.get('items');
-      const indexes = new Set<number>();
-      items.forEach((physicalIndex, virtualIndex) => {
-        const size = committed.get(physicalIndex);
-        if (size !== undefined) {
-          sizes[virtualIndex] = size;
-          indexes.add(virtualIndex);
-        }
-      });
-      this.appliedIndexes.set(rowType, indexes);
-      this.providers.dimension.setCustomSizes(rowType, sizes);
-    }
-  }
-
   private readonly scheduleRowDefinitionRemap = () => {
     if (this.rowDefinitionRemapQueued) {
       return;
@@ -515,10 +463,26 @@ export class RowResizePlugin extends BasePlugin {
       if (!this.rowDefinitionRemapQueued) {
         return;
       }
-      this.rowDefinitionRemapQueued = false;
+      this.pruneRowDefinitions();
       this.reapplyRowDefinitionSizes();
+      this.rowDefinitionRemapQueued = false;
     });
   };
+
+  private pruneRowDefinitions() {
+    if (!this.pendingSourceCounts.size) {
+      return;
+    }
+    const definitions = this.providers.dimension.getRowDefinitions();
+    const rowDefinitions = definitions.filter(definition => {
+      const count = this.pendingSourceCounts.get(definition.type);
+      return count === undefined || definition.index < count;
+    });
+    this.pendingSourceCounts.clear();
+    if (rowDefinitions.length !== definitions.length) {
+      this.providers.dimension.setRowDefinitions(rowDefinitions);
+    }
+  }
 
   /** Map source-indexed row definitions back onto the current virtual order. */
   private readonly reapplyRowDefinitionSizes = () => {
@@ -530,7 +494,7 @@ export class RowResizePlugin extends BasePlugin {
           .filter(definition => definition.type === rowType)
           .map(definition => [definition.index, definition.size]),
       );
-      const appliedIndexes = this.appliedIndexes.get(rowType);
+      const appliedIndexes = this.appliedDefinitionIndexes.get(rowType);
       if (!definitions.size && !appliedIndexes?.size) {
         continue;
       }
@@ -540,9 +504,6 @@ export class RowResizePlugin extends BasePlugin {
       for (const index of appliedIndexes || []) {
         delete sizes[index];
       }
-      for (const physicalIndex of definitions.keys()) {
-        delete sizes[physicalIndex];
-      }
       const indexes = new Set<number>();
       items.forEach((physicalIndex, virtualIndex) => {
         const size = definitions.get(physicalIndex);
@@ -551,7 +512,7 @@ export class RowResizePlugin extends BasePlugin {
           indexes.add(virtualIndex);
         }
       });
-      this.appliedIndexes.set(rowType, indexes);
+      this.appliedDefinitionIndexes.set(rowType, indexes);
       const sizeKeys = Object.keys(sizes);
       if (
         sizeKeys.length !== Object.keys(currentSizes).length ||
@@ -585,6 +546,7 @@ export class RowResizePlugin extends BasePlugin {
     this.cancel('destroy');
     this.keepBottomAnchor = false;
     this.rowDefinitionRemapQueued = false;
+    this.pendingSourceCounts.clear();
     super.destroy();
   }
 }

--- a/test/grouping.spec.ts
+++ b/test/grouping.spec.ts
@@ -7,7 +7,10 @@ import {
   PSEUDO_GROUP_ITEM,
   PSEUDO_GROUP_ITEM_VALUE,
 } from '../src/plugins/groupingRow/grouping.const';
-import { doCollapse, doExpand } from '../src/plugins/groupingRow/grouping.row.expand.service';
+import {
+  doCollapse,
+  doExpand,
+} from '../src/plugins/groupingRow/grouping.row.expand.service';
 import { GroupingRowPlugin } from '../src/plugins/groupingRow/grouping.row.plugin';
 import { FILTER_TRIMMED_TYPE } from '../src/plugins/filter/filter.plugin';
 import {
@@ -24,7 +27,12 @@ import {
   TRIMMED_GROUPING,
 } from '../src/plugins/groupingRow/grouping.trimmed.service';
 
-function groupRow(name: string, depth: number, expanded = false, path: string[] = [name]): DataType {
+function groupRow(
+  name: string,
+  depth: number,
+  expanded = false,
+  path: string[] = [name],
+): DataType {
   return {
     [PSEUDO_GROUP_ITEM]: name,
     [GROUP_DEPTH]: depth,
@@ -45,6 +53,11 @@ describe('row grouping', () => {
       groups: {},
       groupingCustomRenderer: undefined,
       groupingCellRenderer: undefined,
+      rowDefinitions: [] as Array<{
+        type: 'rgRow';
+        index: number;
+        size: number;
+      }>,
     };
     const store = {
       get: (key: keyof typeof state) => state[key],
@@ -79,7 +92,8 @@ describe('row grouping', () => {
           state.proxyItems = nextSource.map((_, index) => index);
           state.items = [...state.proxyItems];
         }),
-        setGrouping: jest.fn(({
+        setGrouping: jest.fn(
+          ({
           depth,
           customRenderer,
           cellRenderer,
@@ -91,7 +105,8 @@ describe('row grouping', () => {
           state.groupingDepth = depth;
           state.groupingCustomRenderer = customRenderer;
           state.groupingCellRenderer = cellRenderer;
-        }),
+          },
+        ),
       },
       column: {
         getColumns: jest.fn(() => [{ prop: 'name' }, { prop: 'team' }]),
@@ -99,6 +114,12 @@ describe('row grouping', () => {
       },
       plugins: {
         getByClass: jest.fn(() => undefined),
+      },
+      dimension: {
+        getRowDefinitions: jest.fn(() => state.rowDefinitions),
+        setRowDefinitions: jest.fn(definitions => {
+          state.rowDefinitions = definitions;
+        }),
       },
     };
 
@@ -729,6 +750,25 @@ describe('row grouping', () => {
   });
 
   describe('sorting integration', () => {
+    it('remaps group-header and child row definitions by their identities', () => {
+      const { plugin, state } = createGroupingPlugin([
+        { name: 'Alice', team: 'North' },
+        { name: 'Ben', team: 'North' },
+        { name: 'Cara', team: 'South' },
+      ]);
+      plugin.setGrouping({ props: ['team'], expandedAll: true });
+      state.rowDefinitions = [
+        { type: 'rgRow', index: 0, size: 48 },
+        { type: 'rgRow', index: 1, size: 60 },
+      ];
+
+      plugin.setGrouping({ props: ['team'], expandedAll: true });
+
+      expect(state.rowDefinitions).toEqual([
+        { type: 'rgRow', index: 0, size: 48 },
+        { type: 'rgRow', index: 1, size: 60 },
+      ]);
+    });
     it('builds grouping from physical order when the current proxy is sorted', () => {
       const { plugin, providers, state } = createGroupingPlugin([
         { name: 'Charlie', team: 'North' },

--- a/test/row-resize.spec.ts
+++ b/test/row-resize.spec.ts
@@ -7,16 +7,86 @@ import {
   RowResizePlugin,
   resolveRowResizeConfig,
 } from '../src/plugins/row-resize';
+import { PluginService } from '../src/components/revoGrid/plugin.service';
 import type { PluginProviders } from '../src/types';
 
 describe('row resize utilities', () => {
-  it('syncs config from the host property and plugin provider', () => {
+  function createPluginHarness(resizeRow: HTMLRevoGridElement['resizeRow']) {
+    const grid = {
+      resizeRow,
+      plugins: [] as Array<typeof RowResizePlugin>,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      refresh: jest.fn(),
+    } as unknown as HTMLRevoGridElement;
+    const pluginService = new PluginService();
+    const providers = {
+      plugins: pluginService,
+    } as unknown as PluginProviders;
+
+    return { grid, pluginService, providers };
+  }
+
+  it('keeps the core plugin dormant until configured subclasses are registered', () => {
+    class ConfiguredRowResizePlugin extends RowResizePlugin {}
+    const { grid, pluginService, providers } = createPluginHarness(true);
+
+    const corePlugin = new RowResizePlugin(grid, providers);
+
+    expect(grid.addEventListener).not.toHaveBeenCalled();
+    expect(corePlugin.subscriptions).toEqual({});
+
+    pluginService.add(corePlugin);
+    grid.plugins = [ConfiguredRowResizePlugin];
+    pluginService.addUserPluginsAndCreate(
+      grid,
+      [ConfiguredRowResizePlugin],
+      [],
+      providers,
+    );
+    corePlugin.syncGridConfig();
+
+    expect(corePlugin.subscriptions).toEqual({});
+    pluginService.destroy();
+  });
+
+  it('preserves subclass constructor config when it becomes the row-resize lookup result', () => {
+    class ConfiguredRowResizePlugin extends RowResizePlugin {
+      constructor(grid: HTMLRevoGridElement, providers: PluginProviders) {
+        super(grid, providers, { minHeight: 50, maxHeight: 80 });
+      }
+    }
+    const { grid, pluginService, providers } = createPluginHarness(false);
+    const corePlugin = new RowResizePlugin(grid, providers);
+    const configuredPlugin = new ConfiguredRowResizePlugin(grid, providers);
+    pluginService.add(corePlugin);
+    pluginService.add(configuredPlugin);
+
+    pluginService.addUserPluginsAndCreate(
+      grid,
+      [ConfiguredRowResizePlugin],
+      [RowResizePlugin, ConfiguredRowResizePlugin],
+      providers,
+    );
+    const lookupResult = pluginService.getByClass(RowResizePlugin);
+    lookupResult?.syncGridConfig();
+
+    expect(lookupResult).toBe(configuredPlugin);
+    expect(
+      (
+        configuredPlugin as unknown as {
+          config: { minHeight: number; maxHeight?: number };
+        }
+      ).config,
+    ).toMatchObject({ minHeight: 50, maxHeight: 80 });
+    pluginService.destroy();
+  });
+
+  it('syncs config from host properties', () => {
     class ConfiguredRowResizePlugin extends RowResizePlugin {}
     const grid = {
       resizeRow: false,
-      get plugins(): never {
-        throw new Error('plugins must be supplied by the component');
-      },
+      plugins: [],
       get rowDefinitions(): never {
         throw new Error('rowDefinitions must be read from the provider');
       },
@@ -24,14 +94,8 @@ describe('row resize utilities', () => {
       removeEventListener: jest.fn(),
       refresh: jest.fn(),
     } as unknown as HTMLRevoGridElement;
-    const registeredPlugins: RowResizePlugin[] = [];
-    const providers = {
-      plugins: {
-        get: () => registeredPlugins,
-      },
-    } as unknown as PluginProviders;
+    const providers = {} as PluginProviders;
     const plugin = new RowResizePlugin(grid, providers);
-    registeredPlugins.push(plugin);
 
     expect(grid.addEventListener).not.toHaveBeenCalled();
 
@@ -42,17 +106,15 @@ describe('row resize utilities', () => {
     const subscriptionCount = (grid.addEventListener as jest.Mock).mock.calls
       .length;
 
-    registeredPlugins.push(
-      Object.create(ConfiguredRowResizePlugin.prototype),
-    );
+    grid.plugins = [ConfiguredRowResizePlugin];
     plugin.syncGridConfig();
     expect(grid.removeEventListener).toHaveBeenCalled();
 
-    registeredPlugins.pop();
+    grid.plugins = [];
     plugin.syncGridConfig();
-    expect((grid.addEventListener as jest.Mock).mock.calls.length).toBeGreaterThan(
-      subscriptionCount,
-    );
+    expect(
+      (grid.addEventListener as jest.Mock).mock.calls.length,
+    ).toBeGreaterThan(subscriptionCount);
 
     plugin.destroy();
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a lifecycle event before grouping changes are applied.
  - Improved row resizing to preserve custom row and group-header heights across sorting, filtering, grouping, regrouping, source updates, and row reordering.
  - Added support for retaining independently sized rows when indexes change.

- **Bug Fixes**
  - Prevented row-size loss during data updates and grouping operations.
  - Improved row-resize plugin activation and cancellation behavior.
  - Preserved provider-defined sizes for main and pinned rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->