### PR TITLE
feat/provided default filter scenario

### DIFF
--- a/e2e/filtering.spec.ts
+++ b/e2e/filtering.spec.ts
@@ -192,6 +192,263 @@ test.describe('filtering', () => {
     ]);
   });
 
+  test('shows column defaults as inactive drafts', async ({ page }) => {
+    const columns = buildColumns([
+      {
+        prop: 'role',
+        name: 'Role',
+        filter: true,
+        ...withHeaderTestId('default-string-filter'),
+      },
+      {
+        prop: 'score',
+        name: 'Score',
+        filter: 'number',
+        ...withHeaderTestId('default-number-filter'),
+      },
+      {
+        prop: 'city',
+        name: 'City',
+        filter: { type: 'string', default: 'eq' },
+        ...withHeaderTestId('overridden-string-filter'),
+      },
+    ]);
+
+    await mountGrid(page, {
+      columns,
+      source: [
+        { role: 'Admin', score: 10, city: 'Lisbon' },
+        { role: 'Editor', score: 20, city: 'Porto' },
+      ],
+      filter: true,
+    });
+
+    await page.evaluate(() => {
+      const grid = document.querySelector('revo-grid');
+      if (!grid) throw new Error('Grid not found');
+      (window as any).__draftFilterEvents = [];
+      grid.addEventListener('beforefilterapply', () =>
+        (window as any).__draftFilterEvents.push('before'),
+      );
+      grid.addEventListener('afterfilterapply', () =>
+        (window as any).__draftFilterEvents.push('after'),
+      );
+    });
+
+    const panel = page.locator(SELECTORS.filterPanel);
+    for (const [testId, expectedType] of [
+      ['default-string-filter', 'contains'],
+      ['default-number-filter', 'eqN'],
+      ['overridden-string-filter', 'eq'],
+    ] as const) {
+      const button = page.getByTestId(testId).locator(SELECTORS.filterButton);
+      await button.click();
+      await expect(panel.locator('.select-filter')).toHaveCount(1);
+      await expect(panel.locator('.select-filter')).toHaveValue(expectedType);
+      await expect(button).not.toHaveClass(/active/);
+      await expect(mainDataRows(page)).toHaveCount(2);
+      await panel.getByRole('button', { name: 'ok' }).click();
+    }
+
+    await page.waitForTimeout(500);
+    expect(
+      await page.evaluate(() => (window as any).__draftFilterEvents),
+    ).toEqual([]);
+  });
+
+  test('disables default drafts grid-wide unless a column explicitly opts in', async ({ page }) => {
+    const columns = buildColumns([
+      {
+        prop: 'role',
+        name: 'Role',
+        filter: true,
+        ...withHeaderTestId('globally-disabled-default-filter'),
+      },
+      {
+        prop: 'city',
+        name: 'City',
+        filter: { type: 'string', default: 'eq' },
+        ...withHeaderTestId('explicitly-enabled-default-filter'),
+      },
+    ]);
+
+    await mountGrid(page, {
+      columns,
+      source: [{ role: 'Admin', city: 'Lisbon' }],
+      filter: { defaultFilter: false },
+    });
+
+    const panel = page.locator(SELECTORS.filterPanel);
+    await page
+      .getByTestId('globally-disabled-default-filter')
+      .locator(SELECTORS.filterButton)
+      .click();
+    await expect(panel.locator('.select-filter')).toHaveCount(0);
+    await panel.getByRole('button', { name: 'ok' }).click();
+
+    await page
+      .getByTestId('explicitly-enabled-default-filter')
+      .locator(SELECTORS.filterButton)
+      .click();
+    await expect(panel.locator('.select-filter')).toHaveCount(1);
+    await expect(panel.locator('.select-filter')).toHaveValue('eq');
+  });
+
+  test('disables a default draft for an individual column', async ({ page }) => {
+    const columns = buildColumns([
+      {
+        prop: 'role',
+        name: 'Role',
+        filter: { type: 'string', default: false },
+        ...withHeaderTestId('column-disabled-default-filter'),
+      },
+      {
+        prop: 'city',
+        name: 'City',
+        filter: 'string',
+        ...withHeaderTestId('column-enabled-default-filter'),
+      },
+    ]);
+
+    await mountGrid(page, {
+      columns,
+      source: [{ role: 'Admin', city: 'Lisbon' }],
+      filter: true,
+    });
+
+    const panel = page.locator(SELECTORS.filterPanel);
+    await page
+      .getByTestId('column-disabled-default-filter')
+      .locator(SELECTORS.filterButton)
+      .click();
+    await expect(panel.locator('.select-filter')).toHaveCount(0);
+    await panel.getByRole('button', { name: 'ok' }).click();
+
+    await page
+      .getByTestId('column-enabled-default-filter')
+      .locator(SELECTORS.filterButton)
+      .click();
+    await expect(panel.locator('.select-filter')).toHaveValue('contains');
+  });
+
+  test('promotes an explicitly selected no-input draft and reseeds only after reopen', async ({ page }) => {
+    const columns = buildColumns([
+      {
+        prop: 'role',
+        name: 'Role',
+        filter: true,
+        ...withHeaderTestId('promoted-default-filter'),
+      },
+    ]);
+
+    await mountGrid(page, {
+      columns,
+      source: [{ role: 'Admin' }, { role: '' }],
+      filter: true,
+    });
+
+    const button = page
+      .getByTestId('promoted-default-filter')
+      .locator(SELECTORS.filterButton);
+    const panel = page.locator(SELECTORS.filterPanel);
+    await button.click();
+    await panel.locator('.select-filter').selectOption('notEmpty');
+
+    await expect(mainDataRows(page)).toHaveCount(1);
+    await expect(button).toHaveClass(/active/);
+
+    await panel.getByRole('button', { name: 'reset' }).click();
+    await expect(mainDataRows(page)).toHaveCount(2);
+    await expect(panel.locator('.select-filter')).toHaveCount(0);
+    await expect(button).not.toHaveClass(/active/);
+
+    await panel.getByRole('button', { name: 'ok' }).click();
+    await button.click();
+    await expect(panel.locator('.select-filter')).toHaveValue('contains');
+
+    await panel.getByRole('button', { name: 'Remove filter' }).click();
+    await expect(panel.locator('.select-filter')).toHaveCount(0);
+    await panel.getByRole('button', { name: 'ok' }).click();
+    await button.click();
+    await expect(panel.locator('.select-filter')).toHaveValue('contains');
+  });
+
+  test('replaces an untouched draft when adding a condition', async ({ page }) => {
+    const columns = buildColumns([
+      {
+        prop: 'role',
+        name: 'Role',
+        filter: true,
+        ...withHeaderTestId('replace-default-filter'),
+      },
+    ]);
+
+    await mountGrid(page, {
+      columns,
+      source: [{ role: 'Admin' }],
+      filter: true,
+    });
+
+    const button = page
+      .getByTestId('replace-default-filter')
+      .locator(SELECTORS.filterButton);
+    const panel = page.locator(SELECTORS.filterPanel);
+    await button.click();
+    await panel.locator('#add-filter').selectOption('eq');
+
+    await expect(panel.locator('.select-filter')).toHaveCount(1);
+    await expect(panel.locator('.select-filter')).toHaveValue('eq');
+    await expect(button).toHaveClass(/active/);
+  });
+
+  test('keeps promoted drafts local until Save when dynamic filtering is disabled', async ({ page }) => {
+    const columns = buildColumns([
+      {
+        prop: 'role',
+        name: 'Role',
+        filter: true,
+        ...withHeaderTestId('saved-default-filter'),
+      },
+    ]);
+
+    await mountGrid(page, {
+      columns,
+      source: [{ role: 'Admin' }, { role: 'Editor' }],
+      filter: { disableDynamicFiltering: true },
+    });
+
+    const button = page
+      .getByTestId('saved-default-filter')
+      .locator(SELECTORS.filterButton);
+    const panel = page.locator(SELECTORS.filterPanel);
+    await page.evaluate(() => {
+      const grid = document.querySelector('revo-grid');
+      if (!grid) throw new Error('Grid not found');
+      (window as any).__savedDraftApplyEvents = 0;
+      grid.addEventListener('beforefilterapply', () => {
+        (window as any).__savedDraftApplyEvents += 1;
+      });
+    });
+    await button.click();
+    await panel.getByRole('button', { name: 'save' }).click();
+    expect(
+      await page.evaluate(() => (window as any).__savedDraftApplyEvents),
+    ).toBe(0);
+    await expect(button).not.toHaveClass(/active/);
+
+    await page.locator(SELECTORS.filterInput).fill('Admin');
+
+    await expect(mainDataRows(page)).toHaveCount(2);
+    await expect(button).not.toHaveClass(/active/);
+
+    await panel.getByRole('button', { name: 'save' }).click();
+    await expect(mainDataRows(page)).toHaveCount(1);
+    await expect(button).toHaveClass(/active/);
+    expect(
+      await page.evaluate(() => (window as any).__savedDraftApplyEvents),
+    ).toBe(1);
+  });
+
   test('allows duplicate operators by default', async ({ page }) => {
     const columns = buildColumns([
       { prop: 'role', name: 'Role', filter: true, ...withHeaderTestId('duplicate-default-role') },
@@ -334,7 +591,7 @@ test.describe('filtering', () => {
 
     const filterPanel = page.locator(SELECTORS.filterPanel);
     await expect(filterPanel).toBeVisible();
-    await filterPanel.getByRole('combobox').selectOption({ label: 'Contains' });
+    await filterPanel.locator('.select-filter').selectOption({ label: 'Contains' });
     await expect(filterPanel.locator('.reorder-button')).toHaveCount(0);
     await page.locator(SELECTORS.filterInput).fill('Admin');
 
@@ -384,7 +641,7 @@ test.describe('filtering', () => {
       }
       const root = host.attachShadow({ mode: 'open' });
       root.innerHTML = `
-        <div style="display: grid; gap: 24px; width: 900px;">
+        <div style="display: grid; gap: 240px; width: 900px;">
           <div style="height: 180px;">
             <revo-grid filter style="display:block; width:100%; height:100%;"></revo-grid>
           </div>
@@ -570,7 +827,7 @@ test.describe('filtering', () => {
       };
     });
 
-    expect(panelTop).toBeGreaterThanOrEqual(8);
+    expect(panelTop).toBeGreaterThanOrEqual(7);
     expect(panelBottom).toBeLessThanOrEqual(buttonTop + 3);
     expect(panelBottom).toBeLessThanOrEqual(viewportBottom - 8);
     expect(Math.abs(actionBottom - panelBottom)).toBeLessThanOrEqual(2);
@@ -608,7 +865,7 @@ test.describe('filtering', () => {
 
     const filterPanel = page.locator(SELECTORS.filterPanel);
     await expect(filterPanel).toBeVisible();
-    await filterPanel.getByRole('combobox').selectOption({ label: 'Contains' });
+    await filterPanel.locator('.select-filter').selectOption({ label: 'Contains' });
     await filterPanel.locator('#add-filter').selectOption({ label: 'Equal' });
 
     const row = filterPanel.locator('.multi-filter-list-row').first();
@@ -661,7 +918,7 @@ test.describe('filtering', () => {
     const filterPanel = page.locator(SELECTORS.filterPanel);
     const filterInputs = page.locator(SELECTORS.filterInput);
     await expect(filterPanel).toBeVisible();
-    await filterPanel.getByRole('combobox').selectOption({ label: 'Contains' });
+    await filterPanel.locator('.select-filter').selectOption({ label: 'Contains' });
     await filterInputs.fill('Admin');
     await filterPanel.locator('#add-filter').selectOption({ label: 'Equal' });
     await filterInputs.nth(1).fill('Engineer');
@@ -754,7 +1011,7 @@ test.describe('filtering', () => {
 
     const filterPanel = page.locator(SELECTORS.filterPanel);
     await expect(filterPanel).toBeVisible();
-    await filterPanel.getByRole('combobox').selectOption({ label: 'Contains' });
+    await filterPanel.locator('.select-filter').selectOption({ label: 'Contains' });
     await page.locator(SELECTORS.filterInput).fill('Admin');
 
     await expectVisibleColumnValues(page, 1, ['Alice', 'Cara']);

--- a/e2e/filtering.spec.ts
+++ b/e2e/filtering.spec.ts
@@ -283,6 +283,7 @@ test.describe('filtering', () => {
       ['overridden-string-filter', 'eq'],
     ] as const) {
       const button = page.getByTestId(testId).locator(SELECTORS.filterButton);
+      await page.getByTestId(testId).hover();
       await button.click();
       await expect(panel.locator('.select-filter')).toHaveCount(1);
       await expect(panel.locator('.select-filter')).toHaveValue(expectedType);
@@ -320,6 +321,7 @@ test.describe('filtering', () => {
     });
 
     const panel = page.locator(SELECTORS.filterPanel);
+    await page.getByTestId('globally-disabled-default-filter').hover();
     await page
       .getByTestId('globally-disabled-default-filter')
       .locator(SELECTORS.filterButton)
@@ -327,6 +329,7 @@ test.describe('filtering', () => {
     await expect(panel.locator('.select-filter')).toHaveCount(0);
     await panel.getByRole('button', { name: 'ok' }).click();
 
+    await page.getByTestId('explicitly-enabled-default-filter').hover();
     await page
       .getByTestId('explicitly-enabled-default-filter')
       .locator(SELECTORS.filterButton)
@@ -358,6 +361,7 @@ test.describe('filtering', () => {
     });
 
     const panel = page.locator(SELECTORS.filterPanel);
+    await page.getByTestId('column-disabled-default-filter').hover();
     await page
       .getByTestId('column-disabled-default-filter')
       .locator(SELECTORS.filterButton)
@@ -365,6 +369,7 @@ test.describe('filtering', () => {
     await expect(panel.locator('.select-filter')).toHaveCount(0);
     await panel.getByRole('button', { name: 'ok' }).click();
 
+    await page.getByTestId('column-enabled-default-filter').hover();
     await page
       .getByTestId('column-enabled-default-filter')
       .locator(SELECTORS.filterButton)
@@ -392,6 +397,7 @@ test.describe('filtering', () => {
       .getByTestId('promoted-default-filter')
       .locator(SELECTORS.filterButton);
     const panel = page.locator(SELECTORS.filterPanel);
+    await page.getByTestId('promoted-default-filter').hover();
     await button.click();
     await panel.locator('.select-filter').selectOption('notEmpty');
 
@@ -404,12 +410,14 @@ test.describe('filtering', () => {
     await expect(button).not.toHaveClass(/active/);
 
     await panel.getByRole('button', { name: 'ok' }).click();
+    await page.getByTestId('promoted-default-filter').hover();
     await button.click();
     await expect(panel.locator('.select-filter')).toHaveValue('contains');
 
     await panel.getByRole('button', { name: 'Remove filter' }).click();
     await expect(panel.locator('.select-filter')).toHaveCount(0);
     await panel.getByRole('button', { name: 'ok' }).click();
+    await page.getByTestId('promoted-default-filter').hover();
     await button.click();
     await expect(panel.locator('.select-filter')).toHaveValue('contains');
   });
@@ -434,6 +442,7 @@ test.describe('filtering', () => {
       .getByTestId('replace-default-filter')
       .locator(SELECTORS.filterButton);
     const panel = page.locator(SELECTORS.filterPanel);
+    await page.getByTestId('replace-default-filter').hover();
     await button.click();
     await panel.locator('#add-filter').selectOption('eq');
 
@@ -470,6 +479,7 @@ test.describe('filtering', () => {
         (window as any).__savedDraftApplyEvents += 1;
       });
     });
+    await page.getByTestId('saved-default-filter').hover();
     await button.click();
     await panel.getByRole('button', { name: 'save' }).click();
     expect(
@@ -496,6 +506,7 @@ test.describe('filtering', () => {
     ]);
 
     await mountGrid(page, { columns, source: [{ id: 1, role: 'Admin' }], filter: true });
+    await page.getByTestId('duplicate-default-role').hover();
     await page
       .getByTestId('duplicate-default-role')
       .locator(SELECTORS.filterButton)
@@ -521,6 +532,7 @@ test.describe('filtering', () => {
       source: [{ id: 1, role: 'Admin', city: 'Lisbon' }],
       filter: { allowDuplicateOperators: false },
     });
+    await page.getByTestId('exclusive-role').hover();
     await page.getByTestId('exclusive-role').locator(SELECTORS.filterButton).click();
 
     const filterPanel = page.locator(SELECTORS.filterPanel);
@@ -532,6 +544,7 @@ test.describe('filtering', () => {
     await expect(filterPanel.locator('.select-filter').nth(1)).toHaveValue('eq');
     await expect(filterPanel.locator('.select-filter').nth(1).locator('option[value="contains"]')).toHaveCount(0);
 
+    await page.getByTestId('exclusive-city').hover();
     await page.getByTestId('exclusive-city').locator(SELECTORS.filterButton).click();
     await expect(filterPanel.locator('#add-filter option[value="contains"]')).toHaveCount(1);
   });
@@ -554,6 +567,7 @@ test.describe('filtering', () => {
         },
       },
     });
+    await page.getByTestId('preloaded-exclusive-role').hover();
     await page.getByTestId('preloaded-exclusive-role').locator(SELECTORS.filterButton).click();
 
     const filterPanel = page.locator(SELECTORS.filterPanel);
@@ -573,6 +587,7 @@ test.describe('filtering', () => {
     ]);
 
     await mountGrid(page, { columns, source: [{ id: 1, role: 'Admin' }], filter: true });
+    await page.getByTestId('runtime-filter-role').hover();
     await page.getByTestId('runtime-filter-role').locator(SELECTORS.filterButton).click();
     const initialFilterPanel = page.locator(SELECTORS.filterPanel);
     await initialFilterPanel.locator('#add-filter').selectOption('contains');
@@ -587,6 +602,7 @@ test.describe('filtering', () => {
       grid.filter = { allowDuplicateOperators: false };
     });
     await page.waitForChanges();
+    await page.getByTestId('runtime-filter-role').hover();
     await page.getByTestId('runtime-filter-role').locator(SELECTORS.filterButton).click();
 
     const filterPanel = page.locator(SELECTORS.filterPanel);
@@ -601,6 +617,7 @@ test.describe('filtering', () => {
       grid.filter = { allowDuplicateOperators: true };
     });
     await page.waitForChanges();
+    await page.getByTestId('runtime-filter-role').hover();
     await page.getByTestId('runtime-filter-role').locator(SELECTORS.filterButton).click();
     await expect(page.locator(`${SELECTORS.filterPanel} .select-filter`).first()).toHaveValue('contains');
     await expect(page.locator(`${SELECTORS.filterPanel} #add-filter option[value="contains"]`)).toHaveCount(1);
@@ -625,6 +642,7 @@ test.describe('filtering', () => {
 
     await expectVisibleColumnValues(page, 1, ['Alice', 'Ben', 'Cara', 'Dan']);
 
+    await page.getByTestId('filter-header-role').hover();
     await page
       .getByTestId('filter-header-role')
       .locator(SELECTORS.filterButton)
@@ -666,6 +684,7 @@ test.describe('filtering', () => {
       .locator(SELECTORS.filterButton);
     const filterPanel = page.locator(SELECTORS.filterPanel);
 
+    await page.getByTestId('toggle-filter-role').hover();
     await filterButton.click();
     await expect(filterPanel).toBeVisible();
 
@@ -738,12 +757,14 @@ test.describe('filtering', () => {
 
     const openFilterPanels = page.locator(`${SELECTORS.filterPanel}[open]`);
 
+    await page.getByTestId('first-filter-role').hover();
     await page
       .getByTestId('first-filter-role')
       .locator(SELECTORS.filterButton)
       .click();
     await expect(openFilterPanels).toHaveCount(1);
 
+    await page.getByTestId('second-filter-role').hover();
     await page
       .getByTestId('second-filter-role')
       .locator(SELECTORS.filterButton)
@@ -780,6 +801,7 @@ test.describe('filtering', () => {
       wrapper.style.overflow = 'hidden';
     });
 
+    await page.getByTestId('dialog-filter-role').hover();
     await page
       .getByTestId('dialog-filter-role')
       .locator(SELECTORS.filterButton)
@@ -839,6 +861,7 @@ test.describe('filtering', () => {
       wrapper.style.marginTop = '160px';
     });
 
+    await page.getByTestId('bottom-filter-role').hover();
     await page
       .getByTestId('bottom-filter-role')
       .locator(SELECTORS.filterButton)
@@ -899,6 +922,7 @@ test.describe('filtering', () => {
       },
     });
 
+    await page.getByTestId('layout-filter-role').hover();
     await page
       .getByTestId('layout-filter-role')
       .locator(SELECTORS.filterButton)
@@ -951,6 +975,7 @@ test.describe('filtering', () => {
 
     await mountGrid(page, { columns, source, filter: true });
 
+    await page.getByTestId('reorder-filter-role').hover();
     await page
       .getByTestId('reorder-filter-role')
       .locator(SELECTORS.filterButton)
@@ -1045,6 +1070,7 @@ test.describe('filtering', () => {
 
     await mountGrid(page, { columns, source, filter: true });
 
+    await page.getByTestId('source-filter-role').hover();
     await page
       .getByTestId('source-filter-role')
       .locator(SELECTORS.filterButton)

--- a/e2e/row-grouping.spec.ts
+++ b/e2e/row-grouping.spec.ts
@@ -677,6 +677,7 @@ test.describe('row grouping', () => {
 
     await expect(mainDataRows(page)).toHaveCount(2);
 
+    await page.getByTestId('group-filter-role').hover();
     await page
       .getByTestId('group-filter-role')
       .locator(SELECTORS.filterButton)
@@ -684,7 +685,7 @@ test.describe('row grouping', () => {
 
     const filterPanel = page.locator(SELECTORS.filterPanel);
     await expect(filterPanel).toBeVisible();
-    await filterPanel.getByRole('combobox').selectOption({ label: 'Contains' });
+    await filterPanel.locator('.select-filter').selectOption({ label: 'Contains' });
     await page.locator(SELECTORS.filterInput).fill('Manager');
 
     const mainGroupRows = page.locator(`${SELECTORS.mainViewport} .groupingRow`);
@@ -784,6 +785,7 @@ test.describe('row grouping', () => {
       rowHeaders: true,
     });
 
+    await page.getByTestId('clear-grouping-filter-role').hover();
     await page
       .getByTestId('clear-grouping-filter-role')
       .locator(SELECTORS.filterButton)
@@ -791,7 +793,7 @@ test.describe('row grouping', () => {
 
     const filterPanel = page.locator(SELECTORS.filterPanel);
     await expect(filterPanel).toBeVisible();
-    await filterPanel.getByRole('combobox').selectOption({ label: 'Contains' });
+    await filterPanel.locator('.select-filter').selectOption({ label: 'Contains' });
     await page.locator(SELECTORS.filterInput).fill('Manager');
 
     await expectVisibleColumnValues(page, 1, ['Cara']);
@@ -836,6 +838,7 @@ test.describe('row grouping', () => {
       rowHeaders: true,
     });
 
+    await page.getByTestId('source-update-filter-role').hover();
     await page
       .getByTestId('source-update-filter-role')
       .locator(SELECTORS.filterButton)
@@ -843,7 +846,7 @@ test.describe('row grouping', () => {
 
     const filterPanel = page.locator(SELECTORS.filterPanel);
     await expect(filterPanel).toBeVisible();
-    await filterPanel.getByRole('combobox').selectOption({ label: 'Contains' });
+    await filterPanel.locator('.select-filter').selectOption({ label: 'Contains' });
     await page.locator(SELECTORS.filterInput).fill('Manager');
 
     await expect(page.locator(`${SELECTORS.mainViewport} .groupingRow`)).toContainText(['South']);

--- a/e2e/row-resize.spec.ts
+++ b/e2e/row-resize.spec.ts
@@ -566,12 +566,13 @@ test.describe('row resize plugin', () => {
     await enableRowResize(page);
     await dragHandle(page, resizeHandle(page, 0), 24);
 
+    await page.getByTestId('row-resize-filter-status').hover();
     await page
       .getByTestId('row-resize-filter-status')
       .locator(SELECTORS.filterButton)
       .click();
     const panel = page.locator(SELECTORS.filterPanel);
-    await panel.getByRole('combobox').selectOption({ label: 'Contains' });
+    await panel.locator('.select-filter').selectOption({ label: 'Contains' });
     await page.locator(SELECTORS.filterInput).fill('keep');
 
     await expect
@@ -620,12 +621,13 @@ test.describe('row resize plugin', () => {
     await enableRowResize(page);
     await dragHandle(page, resizeHandle(page, 0), 24);
 
+    await page.getByTestId('filtered-row-definition-status').hover();
     await page
       .getByTestId('filtered-row-definition-status')
       .locator(SELECTORS.filterButton)
       .click();
     const panel = page.locator(SELECTORS.filterPanel);
-    await panel.getByRole('combobox').selectOption({ label: 'Contains' });
+    await panel.locator('.select-filter').selectOption({ label: 'Contains' });
     await page.locator(SELECTORS.filterInput).fill('keep');
     await expect
       .poll(() => visibleColumnValues(page, 0))
@@ -680,12 +682,13 @@ test.describe('row resize plugin', () => {
     });
     await enableRowResize(page);
 
+    await page.getByTestId('filtered-row-resize-status').hover();
     await page
       .getByTestId('filtered-row-resize-status')
       .locator(SELECTORS.filterButton)
       .click();
     const panel = page.locator(SELECTORS.filterPanel);
-    await panel.getByRole('combobox').selectOption({ label: 'Contains' });
+    await panel.locator('.select-filter').selectOption({ label: 'Contains' });
     await page.locator(SELECTORS.filterInput).fill('keep');
     await expect
       .poll(() => visibleColumnValues(page, 0))
@@ -806,12 +809,13 @@ test.describe('row resize plugin', () => {
       providers?.dimension.setCustomSizes('rgRow', { 6: 81 }, true);
     });
 
+    await page.getByTestId('colliding-row-size-filter-status').hover();
     await page
       .getByTestId('colliding-row-size-filter-status')
       .locator(SELECTORS.filterButton)
       .click();
     const panel = page.locator(SELECTORS.filterPanel);
-    await panel.getByRole('combobox').selectOption({ label: 'Contains' });
+    await panel.locator('.select-filter').selectOption({ label: 'Contains' });
     await page.locator(SELECTORS.filterInput).fill('keep');
     await expect
       .poll(() => visibleColumnValues(page, 0))

--- a/e2e/sorting-filtering.spec.ts
+++ b/e2e/sorting-filtering.spec.ts
@@ -42,11 +42,12 @@ test.describe('sorting and filtering', () => {
     await page.getByTestId('combo-sort-name').click();
     await expectVisibleColumnValues(page, 1, ['Amy', 'Bob', 'Max', 'Zed']);
 
+    await page.getByTestId('combo-filter-role').hover();
     await page
       .getByTestId('combo-filter-role')
       .locator(SELECTORS.filterButton)
       .click();
-    await page.locator(SELECTORS.filterPanel).getByRole('combobox').selectOption({ label: 'Contains' });
+    await page.locator(SELECTORS.filterPanel).locator('.select-filter').selectOption({ label: 'Contains' });
     await page.locator(SELECTORS.filterInput).fill('Admin');
 
     await expectVisibleColumnValues(page, 1, ['Amy', 'Bob', 'Zed']);

--- a/e2e/theme.spec.ts
+++ b/e2e/theme.spec.ts
@@ -346,6 +346,7 @@ test.describe('custom themes', () => {
     );
     await page.keyboard.press('Escape');
 
+    await page.getByTestId('theme-header-name').hover();
     await page
       .getByTestId('theme-header-name')
       .locator(SELECTORS.filterButton)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revolist/revogrid",
-  "version": "4.27.3",
+  "version": "4.27.4",
   "type": "module",
   "description": "Virtual reactive data grid spreadsheet component - RevoGrid.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revolist/revogrid",
-  "version": "4.27.1",
+  "version": "4.27.2",
   "type": "module",
   "description": "Virtual reactive data grid spreadsheet component - RevoGrid.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revolist/revogrid",
-  "version": "4.27.2",
+  "version": "4.27.3",
   "type": "module",
   "description": "Virtual reactive data grid spreadsheet component - RevoGrid.",
   "license": "MIT",

--- a/src/plugins/filter/filter.indexed.ts
+++ b/src/plugins/filter/filter.indexed.ts
@@ -36,6 +36,12 @@ export const filterTypes: Record<string, FilterType[]> = {
   array: ['notEmpty', 'empty'],
 };
 
+/** Preferred initial operator for built-in filter families. */
+export const filterTypeDefaults: Partial<Record<string, FilterType>> = {
+  string: 'contains',
+  number: 'eqN',
+};
+
 export const filterNames = {
   none: 'None',
   empty: 'Is blank',

--- a/src/plugins/filter/filter.panel.tsx
+++ b/src/plugins/filter/filter.panel.tsx
@@ -128,6 +128,7 @@ export class FilterPanel {
   }
 
   @Method() async show(newEntity?: ShowData) {
+    this.debouncedApplyFilter.flush();
     this.hasChanges = false;
     this.changes = newEntity;
     this.filterItems = this.cloneFilterItems(newEntity?.filterItems || {});

--- a/src/plugins/filter/filter.panel.tsx
+++ b/src/plugins/filter/filter.panel.tsx
@@ -136,7 +136,11 @@ export class FilterPanel {
       this.changes.type = this.changes.type || defaultType;
       const prop = this.changes.prop;
       const propFilters = prop === undefined ? undefined : this.filterItems[prop];
-      if (!propFilters?.length && this.changes.showDefaultFilter !== false) {
+      if (
+        !propFilters?.length &&
+        this.changes.showDefaultFilter !== false &&
+        this.changes.hideDefaultFilters !== true
+      ) {
         const type = this.resolveDraftFilterType(
           this.changes.defaultFilterType,
         );

--- a/src/plugins/filter/filter.panel.tsx
+++ b/src/plugins/filter/filter.panel.tsx
@@ -19,6 +19,7 @@ import { AndOrButton, isFilterBtn, ReorderButton, TrashButton } from './filter.b
 import '../../utils/closest.polifill';
 import {
   FilterCaptions,
+  FilterData,
   LogicFunction,
   MultiFilterItem,
   ShowData,
@@ -50,6 +51,7 @@ const VIEWPORT_PADDING = 8;
 })
 export class FilterPanel {
   private dialog?: HTMLDialogElement;
+  private hasChanges = false;
   private filterCaptionsInternal: FilterCaptions = {
     title: 'Filter by',
     ok: 'Close',
@@ -73,6 +75,7 @@ export class FilterPanel {
   @State() currentFilterType: FilterType = defaultType;
   @State() changes: ShowData | undefined;
   @State() filterItems: MultiFilterItem = {};
+  @State() draftFilter: FilterData | undefined;
   @State() draggedFilterId: number | undefined;
   @State() dragOverFilterId: number | undefined;
   @Prop() filterNames: Record<string, string> = {};
@@ -125,10 +128,27 @@ export class FilterPanel {
   }
 
   @Method() async show(newEntity?: ShowData) {
+    this.hasChanges = false;
     this.changes = newEntity;
-    this.filterItems = newEntity?.filterItems || {};
+    this.filterItems = this.cloneFilterItems(newEntity?.filterItems || {});
+    this.draftFilter = undefined;
     if (this.changes) {
       this.changes.type = this.changes.type || defaultType;
+      const prop = this.changes.prop;
+      const propFilters = prop === undefined ? undefined : this.filterItems[prop];
+      if (!propFilters?.length && this.changes.showDefaultFilter !== false) {
+        const type = this.resolveDraftFilterType(
+          this.changes.defaultFilterType,
+        );
+        if (type) {
+          this.draftFilter = {
+            id: ++this.filterId,
+            type,
+            value: '',
+            relation: 'and',
+          };
+        }
+      }
     }
   }
 
@@ -151,8 +171,20 @@ export class FilterPanel {
     const prop = this.changes?.prop;
     if (prop === undefined) return '';
 
-    const propFilters = this.filterItems[prop] ?? [];
-    const visibleFilterCount = propFilters.filter(filter => !filter.hidden).length;
+    const propFilters = (this.filterItems[prop] ?? []).map((filter, index) => ({
+      filter,
+      index,
+      isDraft: false,
+    }));
+    if (this.draftFilter) {
+      propFilters.push({
+        filter: this.draftFilter,
+        index: propFilters.length,
+        isDraft: true,
+      });
+    }
+    const visibleFilters = propFilters.filter(({ filter }) => !filter.hidden);
+    const visibleFilterCount = visibleFilters.length;
     const capts = {
       ...this.filterCaptionsInternal,
       ...this.filterCaptions,
@@ -160,14 +192,14 @@ export class FilterPanel {
     return (
       <div key={this.filterId}>
         <ul class="multi-filter-list-container">
-          {propFilters.map((filter, index) => {
+          {propFilters.map(({ filter, index, isDraft }) => {
             let andOrButton;
             if (filter.hidden) {
               return;
             }
 
             // hide toggle button if there is only one filter and the last one
-            if (index !== this.filterItems[prop].length - 1) {
+            if (visibleFilters[visibleFilterCount - 1]?.filter.id !== filter.id) {
               andOrButton = (
                 <AndOrButton
                   text={filter.relation === 'and' ? capts.and : capts.or}
@@ -176,10 +208,10 @@ export class FilterPanel {
               );
             }
 
-            const extra = this.renderExtra(prop, index);
+            const extra = this.renderExtra(prop, index, isDraft);
             const isDragging = this.draggedFilterId === filter.id;
             const isDragOver = this.dragOverFilterId === filter.id && !isDragging;
-            const canReorder = visibleFilterCount > 1;
+            const canReorder = visibleFilterCount > 1 && !isDraft;
 
             return (
               <li
@@ -219,10 +251,12 @@ export class FilterPanel {
                   <div class={{ 'select-input': true }}>
                     <select
                       class="select-css select-filter"
-                      onChange={e => this.onFilterTypeChange(e, prop, index)}
+                      onChange={e =>
+                        this.onFilterTypeChange(e, prop, index, isDraft)
+                      }
                     >
                       {this.renderSelectOptions(
-                        this.filterItems[prop][index].type,
+                        filter.type,
                         true,
                       )}
                     </select>
@@ -241,7 +275,7 @@ export class FilterPanel {
           })}
         </ul>
 
-        {propFilters.some(f => !f.hidden) ? <div class="add-filter-divider" /> : ''}
+        {visibleFilterCount ? <div class="add-filter-divider" /> : ''}
       </div>
     );
   }
@@ -312,11 +346,24 @@ export class FilterPanel {
     el.style.top = `${top}px`;
   }
 
-  private onFilterTypeChange(e: Event, prop: ColumnProp, index: number) {
+  private onFilterTypeChange(
+    e: Event,
+    prop: ColumnProp,
+    index: number,
+    isDraft = false,
+  ) {
     if (!(e.target instanceof HTMLSelectElement)) {
       return;
     }
-    this.filterItems[prop][index].type = e.target.value as FilterType;
+    const type = e.target.value as FilterType;
+    const filter = isDraft
+      ? this.promoteDraft(prop, type)
+      : this.filterItems[prop][index];
+    if (!filter) {
+      return;
+    }
+    filter.type = type;
+    this.hasChanges = true;
 
     // this re-renders the input to know if we need extra input
     this.filterId++;
@@ -324,7 +371,7 @@ export class FilterPanel {
     // adding setTimeout will wait for the next tick DOM update then focus on input
     setTimeout(() => {
       const input = document.getElementById(
-        'filter-input-' + this.filterItems[prop][index].id,
+        'filter-input-' + filter.id,
       );
       if (input instanceof HTMLInputElement) {
         input.focus();
@@ -337,7 +384,7 @@ export class FilterPanel {
   }
 
   private debouncedApplyFilter = debounce(() => {
-    this.filterChange.emit(this.filterItems);
+    this.emitFilterChange();
   }, 400);
 
   private onAddNewFilter(e: Event) {
@@ -369,13 +416,19 @@ export class FilterPanel {
 
     this.filterId++;
     this.currentFilterId = this.filterId;
-
-    this.filterItems[prop].push({
-      id: this.currentFilterId,
-      type: this.currentFilterType,
-      value: '',
-      relation: 'and',
-    });
+    if (this.draftFilter) {
+      this.draftFilter.id = this.currentFilterId;
+      this.draftFilter.type = this.currentFilterType;
+      this.promoteDraft(prop);
+    } else {
+      this.filterItems[prop].push({
+        id: this.currentFilterId,
+        type: this.currentFilterType,
+        value: '',
+        relation: 'and',
+      });
+      this.hasChanges = true;
+    }
 
     // adding setTimeout will wait for the next tick DOM update then focus on input
     setTimeout(() => {
@@ -387,7 +440,9 @@ export class FilterPanel {
   }
 
   private onSave() {
-    this.filterChange.emit(this.filterItems);
+    if (this.hasChanges) {
+      this.emitFilterChange();
+    }
   }
 
   private onCancel() {
@@ -397,7 +452,12 @@ export class FilterPanel {
   private onReset() {
     this.assertChanges();
 
-    this.resetChange.emit(this.changes?.prop);
+    this.draftFilter = undefined;
+    const prop = this.changes?.prop;
+    if (prop !== undefined) {
+      delete this.filterItems[prop];
+    }
+    this.resetChange.emit(prop);
 
     // this updates the DOM which is used by getFilterItemsList() key
     this.filterId++;
@@ -411,12 +471,18 @@ export class FilterPanel {
 
     const prop = this.changes?.prop;
 
+    if (this.draftFilter?.id === id) {
+      this.draftFilter = undefined;
+      return;
+    }
+
     const items = this.filterItems[prop ?? ''];
     if (!items) return;
 
     const index = items.findIndex(d => d.id === id);
     if (index === -1) return;
     items.splice(index, 1);
+    this.hasChanges = true;
 
     // let's remove the prop if no more filters so the filter icon will be removed
     if (items.length === 0) delete this.filterItems[prop ?? ''];
@@ -466,6 +532,7 @@ export class FilterPanel {
       return;
     }
 
+    this.hasChanges = true;
     this.filterId++;
 
     if (!this.disableDynamicFiltering) {
@@ -505,6 +572,7 @@ export class FilterPanel {
       return;
     }
 
+    this.hasChanges = true;
     this.filterId++;
 
     if (!this.disableDynamicFiltering) {
@@ -527,6 +595,7 @@ export class FilterPanel {
     if (index === -1) return;
 
     items[index].relation = items[index].relation === 'and' ? 'or' : 'and';
+    this.hasChanges = true;
     if (!this.disableDynamicFiltering) {
       this.debouncedApplyFilter();
     }
@@ -604,13 +673,22 @@ export class FilterPanel {
     return options;
   }
 
-  renderExtra(prop: ColumnProp, index: number) {
-    const currentFilter = this.filterItems[prop];
+  renderExtra(prop: ColumnProp, index: number, isDraft = false) {
+    const currentFilter = isDraft
+      ? this.draftFilter
+      : this.filterItems[prop]?.[index];
 
     if (!currentFilter) return '';
 
     const applyFilter = (value?: any) => {
-      this.filterItems[prop][index].value = value;
+      currentFilter.value = value;
+      if (isDraft && !this.isMeaningfulDraftValue(value)) {
+        return;
+      }
+      if (isDraft && !this.promoteDraft(prop)) {
+        return;
+      }
+      this.hasChanges = true;
       if (!this.disableDynamicFiltering) {
         this.debouncedApplyFilter();
       }
@@ -630,11 +708,11 @@ export class FilterPanel {
       ...this.filterCaptionsInternal,
       ...this.filterCaptions,
     };
-    const extra = this.filterEntities[currentFilter[index].type].extra;
+    const extra = this.filterEntities[currentFilter.type]?.extra;
     if (typeof extra === 'function') {
       return extra(h, {
-        value: currentFilter[index].value,
-        filter: currentFilter[index],
+        value: currentFilter.value,
+        filter: currentFilter,
         prop,
         index,
         placeholder: capts.placeholder,
@@ -651,10 +729,10 @@ export class FilterPanel {
     }
     return (
       <input
-        id={`filter-input-${currentFilter[index].id}`}
+        id={`filter-input-${currentFilter.id}`}
         placeholder={capts.placeholder}
         type={extra === 'datepicker' ? 'date' : 'text'}
-        value={currentFilter[index].value}
+        value={currentFilter.value}
         onInput={(e) => {
           if (e.target instanceof HTMLInputElement) {
             applyFilter(e.target.value);
@@ -672,6 +750,48 @@ export class FilterPanel {
           e.stopPropagation();
         }}
       />
+    );
+  }
+
+  private resolveDraftFilterType(preferred?: string): FilterType | undefined {
+    const available = Object.values(this.changes?.filterTypes ?? {}).flat();
+    const type = preferred && available.includes(preferred)
+      ? preferred
+      : available[0];
+    return type as FilterType | undefined;
+  }
+
+  private promoteDraft(prop: ColumnProp, type?: FilterType) {
+    if (!this.draftFilter) {
+      return;
+    }
+    if (!this.filterItems[prop]) {
+      this.filterItems[prop] = [];
+    }
+    if (type) {
+      this.draftFilter.type = type;
+    }
+    const filter = this.draftFilter;
+    this.filterItems[prop].push(filter);
+    this.draftFilter = undefined;
+    this.hasChanges = true;
+    return filter;
+  }
+
+  private isMeaningfulDraftValue(value: any) {
+    return value !== '' && value !== undefined && value !== null;
+  }
+
+  private emitFilterChange() {
+    this.filterChange.emit(this.cloneFilterItems(this.filterItems));
+  }
+
+  private cloneFilterItems(filterItems: MultiFilterItem): MultiFilterItem {
+    return Object.fromEntries(
+      Object.entries(filterItems).map(([prop, filters]) => [
+        prop,
+        filters.map(filter => ({ ...filter })),
+      ]),
     );
   }
 

--- a/src/plugins/filter/filter.plugin.tsx
+++ b/src/plugins/filter/filter.plugin.tsx
@@ -3,6 +3,7 @@ import { h, type VNode } from '@stencil/core';
 
 import type {
   ColumnProp,
+  ColumnFilterOption,
   ColumnRegular,
   DataType,
   PluginProviders,
@@ -12,6 +13,7 @@ import { FILTER_PROP, isFilterBtn } from './filter.button';
 import {
   filterCoreFunctionsIndexedByType,
   filterNames,
+  filterTypeDefaults,
   filterTypes,
 } from './filter.indexed';
 
@@ -57,6 +59,8 @@ export const FILTE_PANEL = 'revogr-filter-panel';
  *
  * @property {FilterLocalization|undefined} localization - translation for filter popup captions.
  *
+ * @property {boolean|undefined} defaultFilter - creates a draft condition when an empty filter panel opens. Defaults to true.
+ *
  * @property {boolean|undefined} disableDynamicFiltering - disables dynamic filtering. A way to apply filters on Save only.
  */
 /**
@@ -76,7 +80,9 @@ export class FilterPlugin extends BasePlugin {
    *    number: ['eqN', 'neqN', 'gt']
    *  }
    */
-  filterByType: Record<string, string[]> = { ...filterTypes };
+  filterByType: Record<string, string[]> = Object.fromEntries(
+    Object.entries(filterTypes).map(([type, filters]) => [type, [...filters]]),
+  );
   filterNameIndexByType: Record<string, string> = {
     ...filterNames,
   };
@@ -211,6 +217,11 @@ export class FilterPlugin extends BasePlugin {
     this.allowDuplicateOperators = config.allowDuplicateOperators ?? true;
     if (this.pop) {
       this.pop.allowDuplicateOperators = this.allowDuplicateOperators;
+      this.pop.disableDynamicFiltering =
+        config.disableDynamicFiltering ?? false;
+      this.pop.closeOnOutsideClick =
+        config.closeFilterPanelOnOutsideClick ?? true;
+      this.pop.filterCaptions = config.localization?.captions;
     }
     if (config.multiFilterItems) {
       this.multiFilterItems = { ...config.multiFilterItems };
@@ -317,6 +328,8 @@ export class FilterPlugin extends BasePlugin {
       anchorY: buttonPos.y,
       autoCorrect: true,
       filterTypes: this.getColumnFilter(e.detail.filter),
+      defaultFilterType: this.getDefaultFilter(e.detail.filter),
+      showDefaultFilter: this.shouldShowDefaultFilter(e.detail.filter),
       filterItems: this.multiFilterItems,
       extraContent: this.extraHyperContent,
       extraBottomContent: this.extraBottomHyperContent,
@@ -326,8 +339,9 @@ export class FilterPlugin extends BasePlugin {
   }
 
   getColumnFilter(
-    type?: boolean | string | string[],
+    config?: ColumnRegular['filter'],
   ): Record<string, string[]> {
+    const type = this.isColumnFilterOption(config) ? config.type : config;
     let filterType = 'string';
     if (!type) {
       return { [filterType]: this.filterByType[filterType] };
@@ -347,6 +361,49 @@ export class FilterPlugin extends BasePlugin {
       }, {});
     }
     return { [filterType]: this.filterByType[filterType] };
+  }
+
+  /** Resolve the preferred operator against the column's available filters. */
+  getDefaultFilter(config?: ColumnRegular['filter']): string | undefined {
+    const filters = this.getColumnFilter(config);
+    const availableFilters = Object.values(filters).flat();
+    const columnDefault = this.isColumnFilterOption(config)
+      ? config.default
+      : undefined;
+
+    if (
+      typeof columnDefault === 'string' &&
+      availableFilters.includes(columnDefault)
+    ) {
+      return columnDefault;
+    }
+
+    const firstFamily = Object.keys(filters)[0];
+    const familyDefault = filterTypeDefaults[firstFamily];
+    if (familyDefault && filters[firstFamily]?.includes(familyDefault)) {
+      return familyDefault;
+    }
+
+    return availableFilters[0];
+  }
+
+  /** Resolve grid and column-level draft opt-outs. */
+  shouldShowDefaultFilter(config?: ColumnRegular['filter']): boolean {
+    if (this.isColumnFilterOption(config)) {
+      if (config.default === false) {
+        return false;
+      }
+      if (typeof config.default === 'string') {
+        return true;
+      }
+    }
+    return this.config?.defaultFilter !== false;
+  }
+
+  private isColumnFilterOption(
+    value?: ColumnRegular['filter'],
+  ): value is ColumnFilterOption {
+    return !!value && typeof value === 'object' && !Array.isArray(value);
   }
 
   isValidType(type: any): type is string {

--- a/src/plugins/filter/filter.types.ts
+++ b/src/plugins/filter/filter.types.ts
@@ -126,6 +126,10 @@ export interface ColumnFilterConfig {
   /** Grid-level blank policy. Individual columns can override fields. */
   blankSemantics?: BlankSemantics;
   /**
+   * Whether empty filter panels start with a draft condition. Defaults to true.
+   */
+  defaultFilter?: boolean;
+  /**
    * The collection of filters to be applied to the column.
    */
   collection?: Record<ColumnProp, FilterCollectionItem>;
@@ -218,6 +222,10 @@ export interface ShowData extends FilterItem, Omit<ColumnRegular, 'filter'> {
    */
   autoCorrect?: boolean;
   filterTypes?: Record<string, string[]>;
+  /** Preferred operator for an empty panel. */
+  defaultFilterType?: string;
+  /** Whether an empty panel should create a draft condition. */
+  showDefaultFilter?: boolean;
   filterItems?: MultiFilterItem;
   // hide default filters
   hideDefaultFilters?: boolean;

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -211,6 +211,20 @@ export interface ColumnType<TModel extends DataType = DataType> extends ColumnPr
   cellParser?: (model: TModel, column: ColumnRegular<ColumnProp, TModel>) => any;
 }
 export type Order = 'asc' | 'desc' | undefined;
+
+/**
+ * Structured filter configuration for an individual column.
+ */
+export interface ColumnFilterOption {
+  /** Filter family, or ordered filter families, available to the column. */
+  type: string | string[];
+  /**
+   * Preferred operator shown when the column has no filter conditions, or false
+   * to disable the draft.
+   */
+  default?: string | false;
+}
+
 /**
  * Interface for regular column definition.
  * Regular column can be any column that is not a grouping column.
@@ -240,7 +254,7 @@ export interface ColumnRegular<P extends ColumnProp = ColumnProp, TModel extends
   /**
    * Filter. Require filter plugin to be installed and activated through grid config filter.
    */
-  filter?: boolean | string | string[];
+  filter?: boolean | string | string[] | ColumnFilterOption;
   /** Partial column override for the grid-level blank filtering policy. */
   blankSemantics?: BlankSemantics;
   /**

--- a/test/filter.spec.ts
+++ b/test/filter.spec.ts
@@ -19,6 +19,7 @@ import type {
   ColumnFilterConfig,
   FilterData,
   FilterEvaluationContext,
+  MultiFilterItem,
   ShowData,
 } from '../src/plugins/filter/filter.types';
 
@@ -120,6 +121,39 @@ describe('default filter resolution', () => {
     } as ShowData);
 
     expect(panel.draftFilter).toBeUndefined();
+  });
+});
+
+describe('filter panel state replacement', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('flushes a pending dynamic change before installing a new entity', async () => {
+    jest.useFakeTimers();
+    const panel = new FilterPanel();
+    const emit = jest.fn();
+    const originalFilterItems = {
+      name: [{ id: 1, type: 'contains', value: 'Ada', relation: 'and' }],
+    } as MultiFilterItem;
+    (panel as any).filterChange = { emit };
+    panel.filterItems = originalFilterItems;
+    (panel as any).debouncedApplyFilter();
+
+    await panel.show({
+      prop: 'role',
+      x: 0,
+      y: 0,
+      filterTypes: { string: ['contains'] },
+      filterItems: {
+        role: [{ id: 2, type: 'contains', value: 'Admin', relation: 'and' }],
+      },
+    } as ShowData);
+
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledWith(originalFilterItems);
+    jest.advanceTimersByTime(400);
+    expect(emit).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/test/filter.spec.ts
+++ b/test/filter.spec.ts
@@ -9,7 +9,11 @@ import { ASYNC_FILTER_ROW_THRESHOLD } from '../src/plugins/filter/filter.constan
 import { getFilterReorderId, moveFilterItem } from '../src/plugins/filter/filter.reorder';
 import { DataStore } from '../src/store/dataSource/data.store';
 import type { ColumnRegular } from '../src';
-import { filterNames, filterTypes } from '../src/plugins/filter/filter.indexed';
+import {
+  filterNames,
+  filterTypeDefaults,
+  filterTypes,
+} from '../src/plugins/filter/filter.indexed';
 import type {
   ColumnFilterConfig,
   FilterData,
@@ -23,6 +27,85 @@ function createFilterPlugin(config: ColumnFilterConfig = {}) {
 
   return new FilterPlugin(revogrid, {} as any, config);
 }
+
+describe('default filter resolution', () => {
+  it('exports and resolves the built-in string and number defaults', () => {
+    const plugin = createFilterPlugin();
+
+    expect(filterTypeDefaults).toEqual({
+      string: 'contains',
+      number: 'eqN',
+    });
+    expect(plugin.getDefaultFilter(true)).toBe('contains');
+    expect(plugin.getDefaultFilter('string')).toBe('contains');
+    expect(plugin.getDefaultFilter('number')).toBe('eqN');
+  });
+
+  it('uses a valid structured column override', () => {
+    const plugin = createFilterPlugin();
+
+    expect(
+      plugin.getColumnFilter({ type: ['string', 'number'], default: 'lte' }),
+    ).toEqual({
+      string: filterTypes.string,
+      number: filterTypes.number,
+    });
+    expect(
+      plugin.getDefaultFilter({ type: ['string', 'number'], default: 'lte' }),
+    ).toBe('lte');
+  });
+
+  it('falls back from invalid or excluded defaults', () => {
+    const plugin = createFilterPlugin({ include: ['empty', 'notEq', 'lte'] });
+
+    expect(
+      plugin.getDefaultFilter({ type: 'string', default: 'missing' }),
+    ).toBe('empty');
+    expect(
+      plugin.getDefaultFilter({ type: 'number', default: 'eqN' }),
+    ).toBe('empty');
+  });
+
+  it('uses the first operator from the first custom family without a default', () => {
+    const plugin = createFilterPlugin({
+      customFilters: {
+        selected: {
+          columnFilterType: 'selection',
+          name: 'Selected',
+          func: () => true,
+        },
+        notSelected: {
+          columnFilterType: 'selection',
+          name: 'Not selected',
+          func: () => true,
+        },
+      },
+    });
+
+    expect(plugin.getDefaultFilter('selection')).toBe('selected');
+    expect(plugin.getDefaultFilter(['selection', 'number'])).toBe('selected');
+    expect(
+      plugin.getDefaultFilter({
+        type: ['selection', 'number'],
+        default: 'eqN',
+      }),
+    ).toBe('eqN');
+  });
+
+  it('supports grid and column-level default draft opt-outs', () => {
+    const enabledPlugin = createFilterPlugin();
+    const disabledPlugin = createFilterPlugin({ defaultFilter: false });
+
+    expect(enabledPlugin.shouldShowDefaultFilter('string')).toBe(true);
+    expect(
+      enabledPlugin.shouldShowDefaultFilter({ type: 'string', default: false }),
+    ).toBe(false);
+    expect(disabledPlugin.shouldShowDefaultFilter('string')).toBe(false);
+    expect(
+      disabledPlugin.shouldShowDefaultFilter({ type: 'string', default: 'eq' }),
+    ).toBe(true);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // eq / notEq

--- a/test/filter.spec.ts
+++ b/test/filter.spec.ts
@@ -5,6 +5,7 @@ import beginsWith from '../src/plugins/filter/conditions/string/beginswith';
 import gtThan from '../src/plugins/filter/conditions/number/greaterThan';
 import lt from '../src/plugins/filter/conditions/number/lessThan';
 import { FilterPlugin } from '../src/plugins/filter/filter.plugin';
+import { FilterPanel } from '../src/plugins/filter/filter.panel';
 import { ASYNC_FILTER_ROW_THRESHOLD } from '../src/plugins/filter/filter.constants';
 import { getFilterReorderId, moveFilterItem } from '../src/plugins/filter/filter.reorder';
 import { DataStore } from '../src/store/dataSource/data.store';
@@ -18,6 +19,7 @@ import type {
   ColumnFilterConfig,
   FilterData,
   FilterEvaluationContext,
+  ShowData,
 } from '../src/plugins/filter/filter.types';
 
 function createFilterPlugin(config: ColumnFilterConfig = {}) {
@@ -104,6 +106,20 @@ describe('default filter resolution', () => {
     expect(
       disabledPlugin.shouldShowDefaultFilter({ type: 'string', default: 'eq' }),
     ).toBe(true);
+  });
+
+  it('does not seed a hidden draft for panels owned by another plugin', async () => {
+    const panel = new FilterPanel();
+
+    await panel.show({
+      prop: 'name',
+      x: 0,
+      y: 0,
+      filterTypes: { string: ['contains'] },
+      hideDefaultFilters: true,
+    } as ShowData);
+
+    expect(panel.draftFilter).toBeUndefined();
   });
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filter panels now offer a default draft condition for empty columns, using an appropriate operator automatically.
  * Configure preferred operators per column, disable default drafts per column, or disable them across the grid.
  * Added support for structured column filter configuration, including filter families and preferred operators.
  * Draft conditions become active when configured with a meaningful value and can be replaced or reset as needed.

* **Bug Fixes**
  * Unsaved edits remain local until explicitly saved when dynamic filtering is disabled.
  * Resetting filters now clears pending draft conditions consistently.
  * Filter-only headers and filter controls now remain clearly visible and accessible.
  * Pending filter updates are applied before switching panel contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->